### PR TITLE
Add env config and docs for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore Python cache and env files
+__pycache__/
+*.pyc
+*.pyo
+.env
+
+# Node dependencies and build output
+node_modules/
+frontend/dist/
+
+# IDE files
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Garmin Activity Dashboard
+
+This project contains a minimal React frontend and FastAPI backend used to mock
+Garmin activity data. The frontend uses Vite and Tailwind CSS while the backend
+serves dummy endpoints.
+
+## Local Development
+
+1. **Backend**
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+   ```
+2. **Frontend**
+   ```bash
+   cd frontend
+   npm install
+   cp .env.example .env  # contains VITE_BACKEND_URL
+   npm run dev
+   ```
+
+## Configuration
+
+The frontend expects `VITE_BACKEND_URL` to point at the FastAPI server. When
+running locally this defaults to `http://localhost:8000`.
+
+## Deploying to Vercel
+
+Create a new project in Vercel and set the **root directory** to `frontend`.
+Add the `VITE_BACKEND_URL` environment variable in the Vercel dashboard so the
+frontend knows where to reach your backend. Vercel will run `npm run build` and
+serve the generated static files from `frontend/dist`.
+
+The backend can be hosted separately on any platform that supports FastAPI.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the FastAPI backend
+VITE_BACKEND_URL=http://localhost:8000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,12 +4,16 @@ export default function App() {
   const [activities, setActivities] = useState([]);
   const [error, setError] = useState(null);
 
+  const rawBase = import.meta.env.VITE_BACKEND_URL || "";
+  const baseUrl = rawBase.replace(/\/$/, "");
+
   useEffect(() => {
-    fetch("http://localhost:8000/activities?start=0&limit=20")
-      .then(res => res.json())
+    const url = `${baseUrl}/activities?start=0&limit=20`;
+    fetch(url)
+      .then((res) => res.json())
       .then(setActivities)
       .catch(setError);
-  }, []);
+  }, [baseUrl]);
 
   if (error) return <div className="p-4 text-red-600">Error: {error.toString()}</div>;
   if (!activities.length) return <div className="p-4">Loading…</div>;


### PR DESCRIPTION
## Summary
- document local dev and Vercel deployment
- load backend URL from env in the frontend
- provide example `.env`
- ignore common generated files

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886ce6162e48324b455497a28978e81