### PR TITLE
Add metric endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,3 +13,15 @@ This backend serves dummy data until real Garmin credentials are available.
    ```
    uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
    ```
+
+## Endpoints
+
+The API exposes several dummy routes returning JSON data:
+
+- `GET /activities` – list recent activities
+- `GET /activities/{activity_id}` – detail for a specific activity
+- `GET /steps` – daily step counts
+- `GET /heartrate` – hourly heart rate samples
+- `GET /vo2max` – weekly VO2 max values
+- `GET /sleep` – nightly sleep duration in hours
+- `GET /map` – miscellaneous map metric points

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import datetime
+import random
 
 app = FastAPI(title="Dummy Garmin Activity API")
 app.add_middleware(
@@ -36,3 +37,52 @@ async def activity(activity_id: str):
                 "startTimeLocal": act["startTimeLocal"]
             }
     raise HTTPException(status_code=404, detail="Activity not found")
+
+
+def _metric_points(count: int, start: datetime.datetime, delta: datetime.timedelta, low: int, high: int):
+    """Helper to generate metric points"""
+    points = []
+    for i in range(count):
+        ts = (start + delta * i).isoformat()
+        value = random.randint(low, high)
+        points.append({"timestamp": ts, "value": value})
+    return points
+
+
+@app.get("/steps")
+async def steps():
+    """Return dummy daily step counts for the past week."""
+    now = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) - datetime.timedelta(days=6)
+    return _metric_points(7, now, datetime.timedelta(days=1), 3000, 12000)
+
+
+@app.get("/heartrate")
+async def heartrate():
+    """Return dummy heart rate values for the past 24 hours."""
+    now = datetime.datetime.now() - datetime.timedelta(hours=23)
+    return _metric_points(24, now, datetime.timedelta(hours=1), 60, 160)
+
+
+@app.get("/vo2max")
+async def vo2max():
+    """Return dummy VO2 max measurements."""
+    start = datetime.datetime.now() - datetime.timedelta(weeks=9)
+    return _metric_points(10, start, datetime.timedelta(weeks=1), 40, 55)
+
+
+@app.get("/sleep")
+async def sleep():
+    """Return dummy nightly sleep duration in hours."""
+    now = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) - datetime.timedelta(days=6)
+    # Sleep hours scaled in minutes but stored as float hours
+    points = _metric_points(7, now, datetime.timedelta(days=1), 5, 9)
+    for p in points:
+        p["value"] = float(p["value"])
+    return points
+
+
+@app.get("/map")
+async def map_endpoint():
+    """Return dummy map metric data."""
+    start = datetime.datetime.now() - datetime.timedelta(minutes=19)
+    return _metric_points(20, start, datetime.timedelta(minutes=1), 0, 100)


### PR DESCRIPTION
## Summary
- add metric endpoints for steps, heartrate, vo2max, sleep, and map
- helper to generate dummy metric points
- document available backend endpoints

## Testing
- `python3 -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6886d3dc031c83249f950b7c805fd8fc