### PR TITLE
Add dashboard components with shadcn primitives

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
+import Header from "./components/Header";
+import KPIGrid from "./components/KPIGrid";
+import TrendsSection from "./components/TrendsSection";
+import MapSection from "./components/MapSection";
 
 export default function App() {
-  const [activities, setActivities] = useState([]);
-  const [error, setError] = useState(null);
-
-  const rawBase = import.meta.env.VITE_BACKEND_URL || "";
-  const baseUrl = rawBase.replace(/\/$/, "");
-
-  useEffect(() => {
-    const url = `${baseUrl}/activities?start=0&limit=20`;
-    fetch(url)
-      .then((res) => res.json())
-      .then(setActivities)
-      .catch(setError);
-  }, [baseUrl]);
-
-  if (error) return <div className="p-4 text-red-600">Error: {error.toString()}</div>;
-  if (!activities.length) return <div className="p-4">Loading…</div>;
-
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Dummy Garmin Activities</h1>
-      <ul className="bg-white p-4 rounded shadow">
-        {activities.map(act => (
-          <li key={act.activityId} className="border-b py-2 last:border-0">
-            <span className="font-semibold">{act.activityType.typeKey}</span>
-             — {new Date(act.startTimeLocal).toLocaleString()}
-          </li>
-        ))}
-      </ul>
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <main className="container mx-auto space-y-6 py-6">
+        <KPIGrid />
+        <TrendsSection />
+        <MapSection />
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/ChartCard.jsx
+++ b/frontend/src/components/ChartCard.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
+
+export default function ChartCard({ title, children }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Card, CardHeader, CardTitle } from "./ui/Card";
+
+export default function Header() {
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle>Garmin Activity Dashboard</CardTitle>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
+import ProgressRing from "./ui/ProgressRing";
+
+export default function KPIGrid() {
+  const items = [
+    { label: "Steps", value: 7000, goal: 10000 },
+    { label: "Sleep", value: 6, goal: 8 },
+    { label: "HR Avg", value: 75, goal: 100 },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {items.map((item) => (
+        <Card key={item.label}>
+          <CardHeader>
+            <CardTitle>{item.label}</CardTitle>
+          </CardHeader>
+          <CardContent className="flex items-center justify-center h-32">
+            <ProgressRing value={item.value} max={item.goal} size={80} />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+
+export default function MapSection() {
+  return (
+    <ChartCard title="Recent Route">
+      <div className="h-64 bg-muted flex items-center justify-center rounded-md">
+        Map
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
+
+export default function TrendsSection() {
+  return (
+    <Tabs defaultValue="steps" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="steps">Steps</TabsTrigger>
+        <TabsTrigger value="heartrate">Heart Rate</TabsTrigger>
+      </TabsList>
+      <TabsContent value="steps">
+        <ChartCard title="Step Trend">
+          <div className="h-40 flex items-center justify-center text-sm text-muted-foreground">
+            Chart
+          </div>
+        </ChartCard>
+      </TabsContent>
+      <TabsContent value="heartrate">
+        <ChartCard title="Heart Rate Trend">
+          <div className="h-40 flex items-center justify-center text-sm text-muted-foreground">
+            Chart
+          </div>
+        </ChartCard>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export function Card({ className = "", children }) {
+  return (
+    <div className={"rounded-lg border bg-card text-card-foreground shadow-sm " + className}>
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ className = "", children }) {
+  return <div className={"flex flex-col space-y-1.5 p-6 " + className}>{children}</div>;
+}
+
+export function CardTitle({ className = "", children }) {
+  return <h3 className={"text-2xl font-semibold leading-none tracking-tight " + className}>{children}</h3>;
+}
+
+export function CardContent({ className = "", children }) {
+  return <div className={"p-6 pt-0 " + className}>{children}</div>;
+}

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function ProgressRing({ value = 0, max = 100, size = 40, stroke = 4, className = "" }) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (value / max) * circumference;
+  return (
+    <svg width={size} height={size} className={className}>
+      <circle
+        className="text-muted-foreground opacity-20"
+        stroke="currentColor"
+        fill="transparent"
+        strokeWidth={stroke}
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+      />
+      <circle
+        className="text-primary"
+        stroke="currentColor"
+        fill="transparent"
+        strokeWidth={stroke}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState } from "react";
+
+const TabsContext = createContext();
+
+export function Tabs({ defaultValue, className = "", children }) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <TabsContext.Provider value={{ value, setValue }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export function TabsList({ className = "", children }) {
+  return (
+    <div className={"inline-flex items-center justify-center rounded-md bg-muted p-1 " + className}>
+      {children}
+    </div>
+  );
+}
+
+export function TabsTrigger({ value, className = "", children }) {
+  const ctx = useContext(TabsContext);
+  const active = ctx.value === value;
+  return (
+    <button
+      onClick={() => ctx.setValue(value)}
+      className={
+        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 " +
+        (active ? "bg-background text-foreground shadow" : "bg-transparent text-muted-foreground") +
+        " " +
+        className
+      }
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({ value, className = "", children }) {
+  const ctx = useContext(TabsContext);
+  if (ctx.value !== value) return null;
+  return <div className={"mt-2 " + className}>{children}</div>;
+}


### PR DESCRIPTION
## Summary
- create a component library under `frontend/src/components`
- use shadcn style primitives (Card, Tabs, ProgressRing)
- build Header, KPI grid, chart cards, trends and map sections
- update `App.jsx` to assemble new dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886d765cb488324ab66b0d277ca9169