### PR TITLE
Add frontend helpers for metrics API

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,15 @@
+const BASE_URL = import.meta.env.VITE_BACKEND_URL || '';
+
+async function apiGet(path) {
+  const res = await fetch(`${BASE_URL}${path}`);
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export const fetchSteps = () => apiGet('/api/steps');
+export const fetchHeartrate = () => apiGet('/api/heartrate');
+export const fetchSleep = () => apiGet('/api/sleep');
+export const fetchVo2max = () => apiGet('/api/vo2max');
+export const fetchMap = () => apiGet('/api/map');

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -1,26 +1,63 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
 import ProgressRing from "./ui/ProgressRing";
+import { fetchHeartrate, fetchSleep, fetchSteps } from "../api";
 
 export default function KPIGrid() {
-  const items = [
-    { label: "Steps", value: 7000, goal: 10000 },
-    { label: "Sleep", value: 6, goal: 8 },
-    { label: "HR Avg", value: 75, goal: 100 },
-  ];
+  const [items, setItems] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    async function load() {
+      try {
+        const [steps, hr, sleep] = await Promise.all([
+          fetchSteps(),
+          fetchHeartrate(),
+          fetchSleep(),
+        ]);
+
+        const latestSteps = steps[steps.length - 1]?.value ?? 0;
+        const avgHr = Math.round(
+          hr.reduce((sum, p) => sum + p.value, 0) / (hr.length || 1)
+        );
+        const lastSleep = sleep[sleep.length - 1]?.value ?? 0;
+
+        setItems([
+          { label: "Steps", value: latestSteps, goal: 10000 },
+          { label: "Sleep", value: lastSleep, goal: 8 },
+          { label: "HR Avg", value: avgHr, goal: 100 },
+        ]);
+      } catch (err) {
+        setError("Failed to load metrics");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
 
   return (
     <div className="grid gap-4 sm:grid-cols-3">
-      {items.map((item) => (
-        <Card key={item.label}>
-          <CardHeader>
-            <CardTitle>{item.label}</CardTitle>
-          </CardHeader>
-          <CardContent className="flex items-center justify-center h-32">
-            <ProgressRing value={item.value} max={item.goal} size={80} />
-          </CardContent>
-        </Card>
-      ))}
+      {loading && (
+        <div className="col-span-3 text-center text-sm text-muted-foreground">
+          Loading...
+        </div>
+      )}
+      {error && (
+        <div className="col-span-3 text-center text-sm text-red-500">{error}</div>
+      )}
+      {!loading && !error &&
+        items.map((item) => (
+          <Card key={item.label}>
+            <CardHeader>
+              <CardTitle>{item.label}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-center h-32">
+              <ProgressRing value={item.value} max={item.goal} size={80} />
+            </CardContent>
+          </Card>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `frontend/src/api.js` with helper wrappers for REST endpoints
- update `KPIGrid` to fetch step, heartrate, and sleep metrics using the helpers
- display loading and error states with Tailwind styles

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886d89cf5f48324bbcdd0260c2d9e7e