### PR TITLE
Update README with venv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,28 @@ This project contains a minimal React frontend and FastAPI backend used to mock
 Garmin activity data. The frontend uses Vite and Tailwind CSS while the backend
 serves dummy endpoints.
 
+We use **Python&nbsp;3** on the backend and a Node/Vite stack on the frontend.
+On macOS with Homebrew‑managed Python you cannot install packages system‑wide
+with plain `pip3`, so all backend dependencies are installed inside a virtual
+environment.
+
 ## Local Development
 
-1. **Backend**
+1. **Backend (FastAPI)**
    ```bash
+   # 1. create & enter your venv
    cd backend
+   python3 -m venv .venv
+   source .venv/bin/activate          # (or `. .venv/bin/activate`)
+
+   # 2. upgrade pip & install deps
+   pip install --upgrade pip
    pip install -r requirements.txt
+
+   # 3. make sure uvicorn is installed
+   #    (uvicorn is in requirements.txt, so pip install -r should have put it in .venv)
+
+   # 4. run the server
    uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
    ```
 2. **Frontend**

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,12 +10,15 @@ This backend serves dummy data until real Garmin credentials are available.
    - `GC_CONSUMER_SECRET`
    - `GC_OAUTH_TOKEN`
    - `GC_OAUTH_TOKEN_SECRET`
-2. Install dependencies:
-   ```
+2. Install dependencies inside a virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
    pip install -r requirements.txt
    ```
 3. Run the server:
-   ```
+   ```bash
    uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
    ```
 


### PR DESCRIPTION
## Summary
- document Python 3 and Node/Vite requirements
- show how to install backend dependencies in a virtual environment
- clarify backend README with venv instructions

## Testing
- `pytest -q`
- `npm test` *(via vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6886e499734c832486c9a63850648219