### PR TITLE
Improve KPI ring animations

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -9,6 +9,7 @@ export default function KPIGrid() {
   const [error, setError] = React.useState(null);
 
   React.useEffect(() => {
+    let interval;
     async function load() {
       try {
         const [steps, hr, sleep] = await Promise.all([
@@ -35,6 +36,8 @@ export default function KPIGrid() {
       }
     }
     load();
+    interval = setInterval(load, 5000);
+    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -16,7 +16,7 @@ export default function ProgressRing({ value = 0, max = 100, size = 40, stroke =
         r={radius}
       />
       <circle
-        className="text-primary"
+        className="text-primary transition-[stroke-dashoffset] duration-500 ease-out"
         stroke="currentColor"
         fill="transparent"
         strokeWidth={stroke}


### PR DESCRIPTION
## Summary
- animate progress rings when strokeDashoffset changes
- refresh KPIs every 5 seconds to make dashboard feel more dynamic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886ea0914ec8324a6699f61f46a8db4