### PR TITLE
Add frontend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ npm test
 
 ## Configuration
 
-The frontend expects `VITE_BACKEND_URL` to point at the FastAPI server. When
-running locally this defaults to `http://localhost:8000`.
+The frontend expects `VITE_BACKEND_URL` to point at the FastAPI server. Copy
+`frontend/.env.example` to `frontend/.env` and adjust if needed. When running
+locally this defaults to `http://localhost:8000`.
 
 ## Deploying to Vercel
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add `.env.example` to frontend
- mention the env file in the configuration instructions

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886eba1b2b48324bf94751829558c3c