### PR TITLE
Add Inter font

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><title>Dummy Garmin Activities</title></head>
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <title>Dummy Garmin Activities</title>
+</head>
 <body class="bg-gray-100">
   <div id="root"></div>
   <script type="module" src="./src/main.jsx"></script>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,7 +6,11 @@ module.exports = {
     "./src/**/*.{js,jsx,ts,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "sans-serif"],
+      },
+    },
   },
 
   // 2a) Use the shadcn preset (recommended) --------------------


### PR DESCRIPTION
## Summary
- load Inter from Google Fonts
- set Inter as the default sans font in Tailwind
- apply the font to the body element

## Testing
- `npx vitest run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886eaad87f48324acf3651fa137405c