### PR TITLE
Add aggregated route heatmap

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -47,3 +47,4 @@ The API exposes several dummy routes returning JSON data:
 - `GET /vo2max` – weekly VO2 max values
 - `GET /sleep` – nightly sleep duration in hours
 - `GET /map` – miscellaneous map metric points
+- `GET /routes` – aggregated coordinates from all activities

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -170,3 +170,25 @@ async def activity_track(activity_id: str):
         for p in points:
             p["temperature"] = weather.get("temperature")
     return points
+
+
+@app.get("/routes")
+async def all_routes():
+    """Return all GPS coordinates from stored activities."""
+    coords = []
+    if garmin_client.has_credentials:
+        activities = garmin_client.get_activities()
+        for act in activities:
+            try:
+                track = garmin_client.get_track(act["activityId"])
+            except KeyError:
+                continue
+            coords.extend({"lat": p["lat"], "lon": p["lon"]} for p in track)
+    else:
+        for act in dummy_activities:
+            start = datetime.datetime.fromisoformat(act["startTimeLocal"])
+            lat = act.get("startLat", base_lat)
+            lon = act.get("startLon", base_lon)
+            for i in range(20):
+                coords.append({"lat": lat + i * 0.001, "lon": lon + i * 0.001})
+    return coords

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -78,3 +78,11 @@ def test_activity_track():
     data = resp.json()
     assert isinstance(data, list)
     assert data and 'timestamp' in data[0] and 'lat' in data[0] and 'lon' in data[0]
+
+
+def test_routes_endpoint():
+    resp = client.get('/routes')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data and 'lat' in data[0] and 'lon' in data[0]

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -18,3 +18,4 @@ export const fetchVo2max = () => apiGet('/vo2max');
 export const fetchMap = () => apiGet('/map');
 export const fetchActivityTrack = (id) => apiGet(`/activities/${id}/track`);
 export const fetchActivitiesByDate = () => apiGet('/activities/by-date');
+export const fetchRoutes = () => apiGet('/routes');

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -1,14 +1,18 @@
 import React from "react";
 import ChartCard from "./ChartCard";
 import ActivityCalendar from "./ActivityCalendar";
-import { fetchActivityTrack } from "../api";
+import { fetchActivityTrack, fetchRoutes } from "../api";
 const LazyMap = React.lazy(() => import("./TrackMap"));
+const LazyHeatmap = React.lazy(() => import("./RouteHeatmap"));
 
 export default function MapSection() {
   const [points, setPoints] = React.useState([]);
   const [center, setCenter] = React.useState(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
+  const [routes, setRoutes] = React.useState([]);
+  const [loadingRoutes, setLoadingRoutes] = React.useState(true);
+  const [errorRoutes, setErrorRoutes] = React.useState(null);
 
   const loadTrack = React.useCallback((act) => {
     setError(null);
@@ -20,24 +24,58 @@ export default function MapSection() {
       .finally(() => setLoading(false));
   }, []);
 
+  React.useEffect(() => {
+    fetchRoutes()
+      .then(setRoutes)
+      .catch(() => setErrorRoutes("Failed to load routes"))
+      .finally(() => setLoadingRoutes(false));
+  }, []);
+
   return (
-    <ChartCard title="Activity Map">
-      <div className="flex flex-col gap-4 sm:flex-row">
-        <div className="sm:w-1/4">
-          <ActivityCalendar onSelect={loadTrack} />
+    <div className="space-y-6">
+      <ChartCard title="Activity Map">
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <div className="sm:w-1/4">
+            <ActivityCalendar onSelect={loadTrack} />
+          </div>
+          <div className="h-64 flex-1 rounded-md bg-muted">
+            {loading && (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Loading...
+              </div>
+            )}
+            {error && (
+              <div className="flex h-full items-center justify-center text-sm text-red-500">
+                {error}
+              </div>
+            )}
+            {!loading && !error && points.length > 0 && (
+              <React.Suspense
+                fallback={
+                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    Loading map...
+                  </div>
+                }
+              >
+                <LazyMap points={points} center={center} />
+              </React.Suspense>
+            )}
+          </div>
         </div>
-        <div className="h-64 flex-1 rounded-md bg-muted">
-          {loading && (
+      </ChartCard>
+      <ChartCard title="Route Heatmap">
+        <div className="h-64 rounded-md bg-muted">
+          {loadingRoutes && (
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
               Loading...
             </div>
           )}
-          {error && (
+          {errorRoutes && (
             <div className="flex h-full items-center justify-center text-sm text-red-500">
-              {error}
+              {errorRoutes}
             </div>
           )}
-          {!loading && !error && points.length > 0 && (
+          {!loadingRoutes && !errorRoutes && routes.length > 0 && (
             <React.Suspense
               fallback={
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -45,12 +83,12 @@ export default function MapSection() {
                 </div>
               }
             >
-              <LazyMap points={points} center={center} />
+              <LazyHeatmap coords={routes} />
             </React.Suspense>
           )}
         </div>
-      </div>
-    </ChartCard>
+      </ChartCard>
+    </div>
   );
 }
 

--- a/frontend/src/components/RouteHeatmap.jsx
+++ b/frontend/src/components/RouteHeatmap.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { MapContainer, TileLayer, CircleMarker } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+export default function RouteHeatmap({ coords }) {
+  if (!coords.length) return null;
+  const center = [coords[0].lat, coords[0].lon];
+  const grid = {};
+  coords.forEach((p) => {
+    const key = `${p.lat.toFixed(3)},${p.lon.toFixed(3)}`;
+    grid[key] = (grid[key] || 0) + 1;
+  });
+  const points = Object.entries(grid).map(([k, count]) => {
+    const [lat, lon] = k.split(",").map(Number);
+    return { lat, lon, count };
+  });
+  const max = Math.max(...points.map((p) => p.count));
+  return (
+    <MapContainer center={center} zoom={13} style={{ height: "100%", width: "100%" }}>
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="&copy; OpenStreetMap contributors"
+      />
+      {points.map((p, i) => (
+        <CircleMarker
+          key={i}
+          center={[p.lat, p.lon]}
+          radius={4 + (8 * p.count) / max}
+          pathOptions={{ color: "#fb923c", fillColor: "#fb923c", fillOpacity: 0.6 }}
+        />
+      ))}
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- expose `/routes` endpoint to gather coordinates from all activities
- document new endpoint
- add frontend API helper and Leaflet heatmap component
- show heatmap alongside existing activity map
- test new backend route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6886f52757348324ae22089deb80431f