### PR TITLE
Add metrics to track points and color-coded map

### DIFF
--- a/backend/app/garmin_client.py
+++ b/backend/app/garmin_client.py
@@ -136,6 +136,8 @@ class GarminClient:
                             "timestamp": ts,
                             "lat": lat + i * 0.001,
                             "lon": lon + i * 0.001,
+                            "heartRate": random.randint(60, 170),
+                            "speed": round(random.uniform(2.5, 6.0), 2),
                         }
                     )
                 return points

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -160,6 +160,8 @@ async def activity_track(activity_id: str):
                         "timestamp": ts,
                         "lat": lat + i * 0.001,
                         "lon": lon + i * 0.001,
+                        "heartRate": random.randint(60, 170),
+                        "speed": round(random.uniform(2.5, 6.0), 2),
                     })
                 break
         else:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -78,6 +78,7 @@ def test_activity_track():
     data = resp.json()
     assert isinstance(data, list)
     assert data and 'timestamp' in data[0] and 'lat' in data[0] and 'lon' in data[0]
+    assert 'heartRate' in data[0] and 'speed' in data[0]
 
 
 def test_routes_endpoint():

--- a/frontend/src/components/LeafletMap.jsx
+++ b/frontend/src/components/LeafletMap.jsx
@@ -2,19 +2,44 @@ import React from "react";
 import { MapContainer, TileLayer, Polyline } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 
-export default function LeafletMap({ points }) {
-  const center = [37.7749, -122.4194];
-  const path = points.map((p, i) => [
-    center[0] + p.value * 0.001,
-    center[1] + i * 0.001,
-  ]);
+export default function LeafletMap({ points, metricKey = "heartRate" }) {
+  if (!points.length) return null;
+  const center = [points[0].lat, points[0].lon];
+
+  const metricValues = points
+    .map((p) => p[metricKey])
+    .filter((v) => v !== undefined && v !== null);
+  const min = Math.min(...metricValues);
+  const max = Math.max(...metricValues);
+
+  const segments = [];
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    const value = curr[metricKey];
+    let ratio = 0;
+    if (max !== min) ratio = (value - min) / (max - min);
+    const hue = 240 - ratio * 240; // blue to red
+    const color = `hsl(${hue}, 100%, 50%)`;
+    segments.push(
+      <Polyline
+        key={i}
+        positions={[
+          [prev.lat, prev.lon],
+          [curr.lat, curr.lon],
+        ]}
+        color={color}
+      />
+    );
+  }
+
   return (
     <MapContainer center={center} zoom={13} style={{ height: "100%", width: "100%" }}>
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution="&copy; OpenStreetMap contributors"
       />
-      <Polyline positions={path} color="#2563eb" />
+      {segments}
     </MapContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add `heartRate` and `speed` data to track points in the backend
- expose these metrics in the `/activities/{id}/track` endpoint
- verify metrics in backend tests
- display polylines in `LeafletMap` using a gradient based on a metric value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm test -- --run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886f719ed588324b6f8f7d5c9bbed81