### PR TITLE
Add frontend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ npm test
 
 ## Configuration
 
-The frontend expects `VITE_BACKEND_URL` to point at the FastAPI server. When
-running locally this defaults to `http://localhost:8000`.
+The frontend expects `VITE_BACKEND_URL` to point at the FastAPI server.
+The provided `frontend/.env.example` file sets this to
+`http://localhost:8000` for local development.
 
 ## Deploying to Vercel
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- provide a `.env.example` for the frontend
- link to this file in the README

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f80fbf2883248a269d6543ddc162