### PR TITLE
Add more weather metrics to track endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -173,6 +173,9 @@ async def activity_track(activity_id: str):
         weather = get_weather(points[0]["lat"], points[0]["lon"], points[0]["timestamp"])
         for p in points:
             p["temperature"] = weather.get("temperature")
+            p["precipitation"] = weather.get("precipitation")
+            p["windspeed"] = weather.get("windspeed")
+            p["humidity"] = weather.get("humidity")
     return points
 
 

--- a/backend/app/weather.py
+++ b/backend/app/weather.py
@@ -20,7 +20,7 @@ def get_weather(lat: float, lon: float, timestamp: str) -> dict:
     params = {
         "latitude": lat,
         "longitude": lon,
-        "hourly": "temperature_2m",
+        "hourly": "temperature_2m,precipitation,windspeed_10m,relativehumidity_2m",
         "start_date": dt.date().isoformat(),
         "end_date": dt.date().isoformat(),
         "timezone": "UTC",
@@ -31,9 +31,17 @@ def get_weather(lat: float, lon: float, timestamp: str) -> dict:
         data = resp.json().get("hourly", {})
         times = data.get("time", [])
         temps = data.get("temperature_2m", [])
-        for t, tmp in zip(times, temps):
+        precip = data.get("precipitation", [])
+        winds = data.get("windspeed_10m", [])
+        humidity = data.get("relativehumidity_2m", [])
+        for idx, t in enumerate(times):
             if t.startswith(dt.strftime("%Y-%m-%dT%H")):
-                return {"temperature": tmp}
+                return {
+                    "temperature": temps[idx] if idx < len(temps) else None,
+                    "precipitation": precip[idx] if idx < len(precip) else None,
+                    "windspeed": winds[idx] if idx < len(winds) else None,
+                    "humidity": humidity[idx] if idx < len(humidity) else None,
+                }
     except Exception:
         pass
-    return {"temperature": None}
+    return {"temperature": None, "precipitation": None, "windspeed": None, "humidity": None}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -79,6 +79,8 @@ def test_activity_track():
     assert isinstance(data, list)
     assert data and 'timestamp' in data[0] and 'lat' in data[0] and 'lon' in data[0]
     assert 'heartRate' in data[0] and 'speed' in data[0]
+    assert 'temperature' in data[0] and 'precipitation' in data[0]
+    assert 'windspeed' in data[0] and 'humidity' in data[0]
 
 
 def test_routes_endpoint():

--- a/frontend/src/components/TrackMap.jsx
+++ b/frontend/src/components/TrackMap.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MapContainer, TileLayer, Polyline, useMap } from "react-leaflet";
+import { MapContainer, TileLayer, Polyline, CircleMarker, Tooltip, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 
 function MapUpdater({ center }) {
@@ -30,9 +30,23 @@ export default function TrackMap({ points, center }) {
   if (!points.length) return null;
   const defaultCenter = [points[0].lat, points[0].lon];
   const segments = [];
-  for (let i = 1; i < Math.min(count, points.length); i++) {
-    const prev = points[i - 1];
+  const markers = [];
+  for (let i = 0; i < Math.min(count, points.length); i++) {
     const curr = points[i];
+    markers.push(
+      <CircleMarker key={`m-${i}`} center={[curr.lat, curr.lon]} radius={3}>
+        <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
+          <div className="text-xs">
+            Temp: {curr.temperature ?? "n/a"}°C<br />
+            Precip: {curr.precipitation ?? "n/a"} mm<br />
+            Wind: {curr.windspeed ?? "n/a"} m/s<br />
+            Humidity: {curr.humidity ?? "n/a"}%
+          </div>
+        </Tooltip>
+      </CircleMarker>
+    );
+    if (i === 0) continue;
+    const prev = points[i - 1];
     const t = curr.temperature;
     let color = "#2563eb";
     if (t !== undefined && t !== null) {
@@ -62,6 +76,7 @@ export default function TrackMap({ points, center }) {
       />
       <MapUpdater center={mapCenter} />
       {segments}
+      {markers}
     </MapContainer>
   );
 }


### PR DESCRIPTION
## Summary
- expand `get_weather` to include precipitation, wind speed and humidity
- attach weather metrics to each GPS point in `activity_track`
- visualize extra data with tooltips in `TrackMap`
- expect new fields in tests

## Testing
- `pytest -q`
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6887667d04088324a68d7ab0e8eb0436