### PR TITLE
Add activity type filter

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,7 +40,7 @@ the built-in dummy responses.
 
 The API exposes several dummy routes returning JSON data:
 
-- `GET /activities` – list recent activities
+- `GET /activities` – list recent activities (optional `type` query param filters by activity type)
 - `GET /activities/by-date` – activities grouped by date with start coordinates
 - `GET /activities/{activity_id}` – detail for a specific activity
 - `GET /steps` – daily step counts

--- a/backend/app/garmin_client.py
+++ b/backend/app/garmin_client.py
@@ -45,10 +45,11 @@ class GarminClient:
         for i in range(1, 6):
             lat = base_lat + random.uniform(-0.02, 0.02)
             lon = base_lon + random.uniform(-0.02, 0.02)
+            act_type = "RUN" if i % 2 else "BIKE"
             activities.append(
                 {
                     "activityId": f"act_{i}",
-                    "activityType": {"typeKey": "RUN"},
+                    "activityType": {"typeKey": act_type},
                     "startTimeLocal": (
                         datetime.datetime.now() - datetime.timedelta(days=i)
                     ).isoformat(),
@@ -64,8 +65,12 @@ class GarminClient:
             self._dummy_activities = self.__init_dummy_activities()
         return self._dummy_activities
 
-    def get_activities(self, start: int = 0, limit: int = 50):
-        return self.dummy_activities[start : start + limit]
+    def get_activities(self, start: int = 0, limit: int = 50, activity_type: str | None = None):
+        acts = self.dummy_activities
+        if activity_type:
+            activity_type = activity_type.lower()
+            acts = [a for a in acts if a["activityType"]["typeKey"].lower() == activity_type]
+        return acts[start : start + limit]
 
     def get_activities_by_date(self):
         """Return activities grouped by date with start coords."""

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -16,6 +16,14 @@ def test_activities_list():
     assert 'activityId' in data[0]
 
 
+def test_activities_filter_type():
+    resp = client.get('/activities?type=run')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data
+    assert all(a['activityType']['typeKey'].lower() == 'run' for a in data)
+
+
 def test_activities_by_date():
     resp = client.get('/activities/by-date')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- support filtering the `/activities` endpoint by an optional `type` query parameter
- vary dummy activity types so there are RUN and BIKE samples
- implement filtering logic in `GarminClient`
- document the new query parameter
- test filtering in backend unit tests

## Testing
- `pytest -q`
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6886fa0a297083248b2ebe2b6f6768da