### PR TITLE
Add metric selector for LeafletMap

### DIFF
--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -2,22 +2,21 @@ import React from "react";
 import ChartCard from "./ChartCard";
 import ActivityCalendar from "./ActivityCalendar";
 import { fetchActivityTrack, fetchRoutes } from "../api";
-const LazyMap = React.lazy(() => import("./TrackMap"));
+const LazyMap = React.lazy(() => import("./LeafletMap"));
 const LazyHeatmap = React.lazy(() => import("./RouteHeatmap"));
 
 export default function MapSection() {
   const [points, setPoints] = React.useState([]);
-  const [center, setCenter] = React.useState(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
   const [routes, setRoutes] = React.useState([]);
   const [loadingRoutes, setLoadingRoutes] = React.useState(true);
   const [errorRoutes, setErrorRoutes] = React.useState(null);
+  const [metric, setMetric] = React.useState("heartRate");
 
   const loadTrack = React.useCallback((act) => {
     setError(null);
     setLoading(true);
-    setCenter([act.lat, act.lon]);
     fetchActivityTrack(act.activityId)
       .then(setPoints)
       .catch(() => setError("Failed to load map"))
@@ -35,8 +34,16 @@ export default function MapSection() {
     <div className="space-y-6">
       <ChartCard title="Activity Map">
         <div className="flex flex-col gap-4 sm:flex-row">
-          <div className="sm:w-1/4">
+          <div className="sm:w-1/4 flex flex-col gap-2">
             <ActivityCalendar onSelect={loadTrack} />
+            <select
+              className="rounded-md border p-1 text-sm"
+              value={metric}
+              onChange={(e) => setMetric(e.target.value)}
+            >
+              <option value="heartRate">Heart Rate</option>
+              <option value="speed">Speed</option>
+            </select>
           </div>
           <div className="h-64 flex-1 rounded-md bg-muted">
             {loading && (
@@ -57,7 +64,7 @@ export default function MapSection() {
                   </div>
                 }
               >
-                <LazyMap points={points} center={center} />
+                <LazyMap points={points} metricKey={metric} />
               </React.Suspense>
             )}
           </div>

--- a/frontend/src/components/__tests__/LeafletMap.test.jsx
+++ b/frontend/src/components/__tests__/LeafletMap.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import LeafletMap from '../LeafletMap';
+import { vi } from 'vitest';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div>{children}</div>,
+  TileLayer: () => null,
+  Polyline: ({ color }) => <div data-testid="polyline" data-color={color} />,
+}));
+
+delete window.L; // ensure no Leaflet global
+
+const points = [
+  { lat: 0, lon: 0, heartRate: 100, speed: 1 },
+  { lat: 0, lon: 1, heartRate: 120, speed: 2 },
+  { lat: 0, lon: 2, heartRate: 110, speed: 3 },
+];
+
+test('updates polyline colors when metric changes', () => {
+  const { rerender } = render(<LeafletMap points={points} metricKey="heartRate" />);
+  const hrColors = screen
+    .getAllByTestId('polyline')
+    .map((el) => el.getAttribute('data-color'));
+
+  rerender(<LeafletMap points={points} metricKey="speed" />);
+  const speedColors = screen
+    .getAllByTestId('polyline')
+    .map((el) => el.getAttribute('data-color'));
+
+  expect(hrColors).not.toEqual(speedColors);
+});
+


### PR DESCRIPTION
## Summary
- use `LeafletMap` in `MapSection`
- add dropdown to select `Heart Rate` vs `Speed`
- pass selected metric to `LeafletMap`
- test that changing the metric updates polyline colors

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68876950826483248966ca8d727e9862