### PR TITLE
Implement month grid activity calendar

### DIFF
--- a/frontend/src/components/ActivityCalendar.jsx
+++ b/frontend/src/components/ActivityCalendar.jsx
@@ -2,18 +2,13 @@ import React from "react";
 import { fetchActivitiesByDate } from "../api";
 
 export default function ActivityCalendar({ onSelect }) {
-  const [days, setDays] = React.useState([]);
+  const [days, setDays] = React.useState({});
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
 
   React.useEffect(() => {
     fetchActivitiesByDate()
-      .then((data) => {
-        const list = Object.keys(data)
-          .sort()
-          .map((date) => ({ date, activities: data[date] }));
-        setDays(list);
-      })
+      .then((data) => setDays(data))
       .catch(() => setError("Failed to load"))
       .finally(() => setLoading(false));
   }, []);
@@ -25,19 +20,52 @@ export default function ActivityCalendar({ onSelect }) {
     return <div className="text-sm text-red-500">{error}</div>;
   }
 
+  const activityDates = Object.keys(days).sort();
+  const first = activityDates.length
+    ? new Date(activityDates[0])
+    : new Date();
+  const year = first.getFullYear();
+  const month = first.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const startOffset = firstDay.getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const cells = [];
+  for (let i = 0; i < startOffset; i++) {
+    cells.push(null);
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    const ds = `${year}-${String(month + 1).padStart(2, "0")}-${String(d).padStart(
+      2,
+      "0"
+    )}`;
+    cells.push(ds);
+  }
+
   return (
-    <ul className="space-y-2">
-      {days.map((d) => (
-        <li key={d.date}>
-          <button
-            onClick={() => onSelect(d.activities[0])}
-            className="w-full rounded-md bg-muted px-2 py-1 text-left hover:bg-muted/70"
-          >
-            {d.date}
-          </button>
-        </li>
-      ))}
-    </ul>
+    <div className="grid grid-cols-7 gap-1 text-sm">
+      {cells.map((date, idx) => {
+        if (!date) return <div key={"empty-" + idx}></div>;
+        const acts = days[date];
+        const dayNum = date.split("-")[2].replace(/^0/, "");
+        if (acts) {
+          return (
+            <button
+              key={date}
+              onClick={() => onSelect(acts[0])}
+              className="rounded-md bg-muted px-2 py-1 hover:bg-muted/70"
+            >
+              {dayNum}
+            </button>
+          );
+        }
+        return (
+          <div key={date} className="text-muted-foreground px-2 py-1 text-center">
+            {dayNum}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/frontend/src/components/__tests__/ActivityCalendar.test.jsx
+++ b/frontend/src/components/__tests__/ActivityCalendar.test.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import ActivityCalendar from '../ActivityCalendar';
 import { vi } from 'vitest';
 
-it('renders dates and triggers selection', async () => {
+it('renders month view and triggers selection', async () => {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: () =>
@@ -15,7 +15,22 @@ it('renders dates and triggers selection', async () => {
   const handler = vi.fn();
   render(<ActivityCalendar onSelect={handler} />);
 
-  const btn = await screen.findByText('2023-01-01');
+  const btn = await screen.findByRole('button', { name: '1' });
   await userEvent.click(btn);
   expect(handler).toHaveBeenCalledWith({ activityId: 'a1', lat: 0, lon: 0 });
+});
+
+it('shows empty days but they are not selectable', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        '2023-01-02': [{ activityId: 'b1', lat: 0, lon: 0 }],
+      }),
+  });
+
+  render(<ActivityCalendar onSelect={() => {}} />);
+
+  await screen.findByText('1'); // ensure day 1 rendered
+  expect(screen.queryByRole('button', { name: '1' })).toBeNull();
 });


### PR DESCRIPTION
## Summary
- replace list rendering with calendar grid layout
- mark days with activities clickable
- extend tests for grid behavior and empty day rendering

## Testing
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68876b2c40f483249e4da27ebbbe8901