### PR TITLE
Add route filtering and UI controls

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -99,6 +99,18 @@ def test_routes_endpoint():
     assert data and 'lat' in data[0] and 'lon' in data[0]
 
 
+def test_routes_filtering():
+    """Filtering by type and date should limit returned coordinates."""
+    list_resp = client.get('/activities')
+    first = list_resp.json()[0]
+    date = first['startTimeLocal'].split('T')[0]
+    resp = client.get(f'/routes?activityType={first["activityType"]["typeKey"]}&startDate={date}&endDate={date}')
+    assert resp.status_code == 200
+    data = resp.json()
+    # each activity produces 20 coordinates
+    assert len(data) == 20
+
+
 def test_daily_totals_endpoint():
     resp = client.get('/daily-totals')
     assert resp.status_code == 200

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -18,6 +18,14 @@ export const fetchVo2max = () => apiGet('/vo2max');
 export const fetchMap = () => apiGet('/map');
 export const fetchActivityTrack = (id) => apiGet(`/activities/${id}/track`);
 export const fetchActivitiesByDate = () => apiGet('/activities/by-date');
-export const fetchRoutes = () => apiGet('/routes');
+export const fetchRoutes = (params = {}) => {
+  const query = new URLSearchParams(
+    Object.fromEntries(
+      Object.entries(params).filter(([, v]) => v !== undefined && v !== '')
+    )
+  ).toString();
+  const qs = query ? `?${query}` : '';
+  return apiGet(`/routes${qs}`);
+};
 export const fetchDailyTotals = () => apiGet('/daily-totals');
 export const fetchAnalysis = () => apiGet('/analysis');

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -12,6 +12,9 @@ export default function MapSection() {
   const [routes, setRoutes] = React.useState([]);
   const [loadingRoutes, setLoadingRoutes] = React.useState(true);
   const [errorRoutes, setErrorRoutes] = React.useState(null);
+  const [activityType, setActivityType] = React.useState("");
+  const [startDate, setStartDate] = React.useState("");
+  const [endDate, setEndDate] = React.useState("");
   const [metric, setMetric] = React.useState("heartRate");
 
   const loadTrack = React.useCallback((act) => {
@@ -24,11 +27,13 @@ export default function MapSection() {
   }, []);
 
   React.useEffect(() => {
-    fetchRoutes()
+    setLoadingRoutes(true);
+    setErrorRoutes(null);
+    fetchRoutes({ activityType, startDate, endDate })
       .then(setRoutes)
       .catch(() => setErrorRoutes("Failed to load routes"))
       .finally(() => setLoadingRoutes(false));
-  }, []);
+  }, [activityType, startDate, endDate]);
 
   return (
     <div className="space-y-6">
@@ -71,6 +76,29 @@ export default function MapSection() {
         </div>
       </ChartCard>
       <ChartCard title="Route Heatmap">
+        <div className="mb-2 flex flex-col gap-2 sm:flex-row">
+          <select
+            className="rounded-md border p-1 text-sm"
+            value={activityType}
+            onChange={(e) => setActivityType(e.target.value)}
+          >
+            <option value="">All Types</option>
+            <option value="run">Run</option>
+            <option value="bike">Bike</option>
+          </select>
+          <input
+            type="date"
+            className="rounded-md border p-1 text-sm"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+          <input
+            type="date"
+            className="rounded-md border p-1 text-sm"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </div>
         <div className="h-64 rounded-md bg-muted">
           {loadingRoutes && (
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- allow optional activity type and date filters on `/routes`
- expose filtered route request through `fetchRoutes`
- fetch heatmap data with filters in `MapSection`
- add UI controls for heatmap filters
- test backend route filtering

## Testing
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68876db1977483249b0c3e47e6545a46