### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <title>Dummy Garmin Activities</title>
 </head>
-<body class="bg-gray-100">
+<body>
   <div id="root"></div>
   <script type="module" src="./src/main.jsx"></script>
 </body>

--- a/frontend/src/components/DarkModeToggle.jsx
+++ b/frontend/src/components/DarkModeToggle.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export default function DarkModeToggle() {
+  const [enabled, setEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    const stored = localStorage.getItem("darkMode");
+    const prefers =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored === null ? prefers : stored === "true";
+    setEnabled(initial);
+    if (initial) document.documentElement.classList.add("dark");
+  }, []);
+
+  const toggle = () => {
+    const next = !enabled;
+    setEnabled(next);
+    localStorage.setItem("darkMode", next);
+    document.documentElement.classList.toggle("dark", next);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+      className="rounded-md border px-2 py-1 text-sm"
+    >
+      {enabled ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Card, CardHeader, CardTitle } from "./ui/Card";
+import DarkModeToggle from "./DarkModeToggle";
 
 export default function Header() {
   return (
     <Card className="mb-4">
-      <CardHeader>
+      <CardHeader className="flex items-center justify-between">
         <CardTitle>Garmin Activity Dashboard</CardTitle>
+        <DarkModeToggle />
       </CardHeader>
     </Card>
   );

--- a/frontend/src/components/__tests__/DarkModeToggle.test.jsx
+++ b/frontend/src/components/__tests__/DarkModeToggle.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DarkModeToggle from '../DarkModeToggle';
+
+it('toggles dark class on html element', async () => {
+  render(<DarkModeToggle />);
+  const btn = screen.getByRole('button', { name: /dark/i });
+  await userEvent.click(btn);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+  await userEvent.click(btn);
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+});

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   // 1. Tell Tailwind where to look for class names:
   content: [
     "./index.html",


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode via `class`
- add DarkModeToggle component and test
- attach toggle to Header
- remove hard-coded body background

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688771eca15c83249bb7ccfefc6c0e93