### PR TITLE
Add custom dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ frontend knows where to reach your backend. Vercel will run `npm run build` and
 serve the generated static files from `frontend/dist`.
 
 The backend can be hosted separately on any platform that supports FastAPI.
+
+## Dark Mode
+
+The UI's colors are now defined with `defineTheme` from the
+`tailwindcss-shadcn-ui` preset. Toggling the "Dark" button switches CSS
+variables so backgrounds become darker and text lightens automatically.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+const { createPreset, defineTheme } = require("tailwindcss-shadcn-ui");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
@@ -16,7 +18,18 @@ module.exports = {
 
   // 2a) Use the shadcn preset (recommended) --------------------
   presets: [
-    require("tailwindcss-shadcn-ui").createPreset(),
+    createPreset({
+      theme: defineTheme({
+        light: {
+          background: "#ffffff",
+          foreground: "#0f172a",
+        },
+        dark: {
+          background: "#0f172a",
+          foreground: "#f8fafc",
+        },
+      }),
+    }),
   ],
 
   // OR 2b) Use it as a plugin -------------------------------


### PR DESCRIPTION
## Summary
- customize Tailwind preset with `defineTheme` for distinct light/dark colors
- update README with dark-mode info

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68877afd4e3483248b9a0220b25cbdae