### PR TITLE
Add extra weather fields

### DIFF
--- a/backend/app/weather.py
+++ b/backend/app/weather.py
@@ -29,21 +29,36 @@ def get_weather(lat: float, lon: float, timestamp: str) -> dict:
     params = {
         "latitude": lat,
         "longitude": lon,
-        "hourly": "temperature_2m",
+        "hourly": (
+            "temperature_2m,precipitation,windspeed_10m,relativehumidity_2m"
+        ),
         "start_date": date_key,
         "end_date": date_key,
         "timezone": "UTC",
     }
-    result = {"temperature": None}
+    result = {
+        "temperature": None,
+        "precipitation": None,
+        "windspeed": None,
+        "humidity": None,
+    }
     try:
         resp = requests.get(API_URL, params=params, timeout=5)
         resp.raise_for_status()
         data = resp.json().get("hourly", {})
         times = data.get("time", [])
         temps = data.get("temperature_2m", [])
-        for t, tmp in zip(times, temps):
+        precs = data.get("precipitation", [])
+        winds = data.get("windspeed_10m", [])
+        hums = data.get("relativehumidity_2m", [])
+        for idx, t in enumerate(times):
             if t.startswith(dt.strftime("%Y-%m-%dT%H")):
-                result = {"temperature": tmp}
+                result = {
+                    "temperature": temps[idx] if idx < len(temps) else None,
+                    "precipitation": precs[idx] if idx < len(precs) else None,
+                    "windspeed": winds[idx] if idx < len(winds) else None,
+                    "humidity": hums[idx] if idx < len(hums) else None,
+                }
                 break
     except Exception:
         pass

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -148,6 +148,9 @@ def test_weather_cached(monkeypatch):
                     "hourly": {
                         "time": [params["start_date"] + "T12:00"],
                         "temperature_2m": [20],
+                        "precipitation": [0.1],
+                        "windspeed_10m": [5.5],
+                        "relativehumidity_2m": [60],
                     }
                 }
 
@@ -159,6 +162,13 @@ def test_weather_cached(monkeypatch):
     result1 = weather.get_weather(lat, lon, ts)
     result2 = weather.get_weather(lat, lon, ts)
 
-    assert result1 == {"temperature": 20}
-    assert result2 == {"temperature": 20}
+    expected = {
+        "temperature": 20,
+        "precipitation": 0.1,
+        "windspeed": 5.5,
+        "humidity": 60,
+    }
+
+    assert result1 == expected
+    assert result2 == expected
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- request precipitation, windspeed and humidity from Open-Meteo
- return these fields from `get_weather`
- extend cached-weather test to cover new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877cbc0d188324a273af47953865d1