### PR TITLE
Update README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ serve the generated static files from `frontend/dist`.
 
 The backend can be hosted separately on any platform that supports FastAPI.
 
+## Frontend Features
+
+The map section lets you replay a selected route with an animated polyline.
+Use the metric dropdown above the map to color the track by heart rate or
+speed.
+
+`ActivityCalendar` renders a simple month view where dates with activities are
+clickable. Hook into the `onSelect` prop to load a track:
+
+```jsx
+<ActivityCalendar onSelect={(act) => console.log(act)} />
+```
+
 ## Dark Mode
 
 The UI's colors are now defined with `defineTheme` from the

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,3 +49,4 @@ The API exposes several dummy routes returning JSON data:
 - `GET /sleep` – nightly sleep duration in hours
 - `GET /map` – miscellaneous map metric points
 - `GET /routes` – aggregated coordinates from all activities
+  (use `activityType`, `startDate` and `endDate` query parameters to filter)


### PR DESCRIPTION
## Summary
- document route heatmap filters in backend API docs
- add frontend docs on metric dropdown, animated playback, and ActivityCalendar

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68877cc0b354832482efe28fb4e61ac6