### PR TITLE
Update theme colors and variable support

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,5 +5,24 @@
 @layer base {
   body {
     @apply font-sans;
+    background-color: var(--color-bg);
+    color: var(--color-primary);
   }
+}
+
+:root {
+  --color-primary: #02343F;
+  --color-bg: #F0EDCC;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-primary: #F0EDCC;
+    --color-bg: #02343F;
+  }
+}
+
+.dark {
+  --color-primary: #F0EDCC;
+  --color-bg: #02343F;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,6 +13,10 @@ module.exports = {
       fontFamily: {
         sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "sans-serif"],
       },
+      colors: {
+        primary: "var(--color-primary)",
+        accent: "var(--color-bg)",
+      },
     },
   },
 
@@ -21,12 +25,12 @@ module.exports = {
     createPreset({
       theme: defineTheme({
         light: {
-          background: "#ffffff",
-          foreground: "#0f172a",
+          background: "#F0EDCC",
+          foreground: "#02343F",
         },
         dark: {
-          background: "#0f172a",
-          foreground: "#f8fafc",
+          background: "#02343F",
+          foreground: "#F0EDCC",
         },
       }),
     }),


### PR DESCRIPTION
## Summary
- tweak Tailwind theme colors
- define CSS custom properties for colors with dark mode override and `.dark` support

## Testing
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688783ea13648324b8c4959ed2c6f1b5