### PR TITLE
Add basic navigation menu

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,11 +8,13 @@ const MapSection = React.lazy(() => import("./components/MapSection"));
 const AnalysisSection = React.lazy(() => import("./components/AnalysisSection"));
 
 export default function App() {
+  const [tab, setTab] = React.useState("dashboard");
+
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <Header />
+      <Header tab={tab} onTabChange={setTab} />
       <main className="container mx-auto space-y-6 py-6">
-        <Tabs defaultValue="dashboard" className="space-y-6">
+        <Tabs value={tab} onValueChange={setTab} className="space-y-6">
           <TabsList className="mb-4">
             <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
             <TabsTrigger value="map">Map</TabsTrigger>

--- a/frontend/src/components/AppNav.jsx
+++ b/frontend/src/components/AppNav.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export default function AppNav({ value, onChange }) {
+  const items = [
+    { label: "Dashboard", value: "dashboard" },
+    { label: "Map", value: "map" },
+    { label: "Analysis", value: "analysis" },
+  ];
+  return (
+    <nav className="flex gap-2">
+      {items.map((item) => (
+        <button
+          key={item.value}
+          onClick={() => onChange(item.value)}
+          className={
+            "px-3 py-1.5 text-sm rounded-md" +
+            (value === item.value
+              ? " bg-accent text-accent-foreground shadow"
+              : " text-muted-foreground hover:text-foreground")
+          }
+        >
+          {item.label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Card, CardHeader, CardTitle } from "./ui/Card";
 import DarkModeToggle from "./DarkModeToggle";
-
-export default function Header() {
+import AppNav from "./AppNav";
+export default function Header({ tab, onTabChange }) {
   return (
     <Card className="mb-4">
-      <CardHeader className="flex items-center justify-between">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle>Garmin Activity Dashboard</CardTitle>
+        <AppNav value={tab} onChange={onTabChange} />
         <DarkModeToggle />
       </CardHeader>
     </Card>

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -2,8 +2,16 @@ import React, { createContext, useContext, useState } from "react";
 
 const TabsContext = createContext();
 
-export function Tabs({ defaultValue, className = "", children }) {
-  const [value, setValue] = useState(defaultValue);
+export function Tabs({
+  defaultValue,
+  value: controlledValue,
+  onValueChange,
+  className = "",
+  children,
+}) {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const value = controlledValue !== undefined ? controlledValue : internalValue;
+  const setValue = onValueChange ?? setInternalValue;
   return (
     <TabsContext.Provider value={{ value, setValue }}>
       <div className={className}>{children}</div>


### PR DESCRIPTION
## Summary
- allow Tabs to be controlled externally
- expose navigation links in header with new `AppNav` component
- track active tab state in `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68879275296c8324a73472af2731c7d7