### PR TITLE
Add shadcn Button & integrate with UI

### DIFF
--- a/frontend/src/components/DarkModeToggle.jsx
+++ b/frontend/src/components/DarkModeToggle.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "./ui/Button";
 
 export default function DarkModeToggle() {
   const [enabled, setEnabled] = React.useState(false);
@@ -20,13 +21,42 @@ export default function DarkModeToggle() {
     document.documentElement.classList.toggle("dark", next);
   };
 
+  const SunIcon = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="h-4 w-4"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-7.364l-1.414 1.414M6.05 17.95l-1.414 1.414M17.95 17.95l-1.414-1.414M6.05 6.05L4.636 4.636M12 8a4 4 0 110 8 4 4 0 010-8z"
+      />
+    </svg>
+  );
+
+  const MoonIcon = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="h-4 w-4"
+    >
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  );
+
   return (
-    <button
+    <Button
       onClick={toggle}
       aria-label="Toggle dark mode"
-      className="rounded-md border px-2 py-1 text-sm"
+      variant="outline"
+      size="sm"
     >
-      {enabled ? "Light" : "Dark"}
-    </button>
+      {enabled ? SunIcon : MoonIcon}
+    </Button>
   );
 }

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const variantClasses = {
+  default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+  outline:
+    "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+  ghost: "hover:bg-accent hover:text-accent-foreground",
+};
+
+const sizeClasses = {
+  default: "h-10 px-4 py-2",
+  sm: "h-9 rounded-md px-3",
+};
+
+export function Button({
+  className = "",
+  variant = "default",
+  size = "default",
+  ...props
+}) {
+  const classes = cn(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    variantClasses[variant],
+    sizeClasses[size],
+    className
+  );
+  return <button className={classes} {...props} />;
+}

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from "react";
+import { Button } from "./Button";
 
 const TabsContext = createContext();
 
@@ -31,17 +32,13 @@ export function TabsTrigger({ value, className = "", children }) {
   const ctx = useContext(TabsContext);
   const active = ctx.value === value;
   return (
-    <button
+    <Button
       onClick={() => ctx.setValue(value)}
-      className={
-        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 " +
-        (active ? "bg-background text-foreground shadow" : "bg-transparent text-muted-foreground") +
-        " " +
-        className
-      }
+      variant={active ? "default" : "ghost"}
+      className={"px-3 py-1.5 text-sm " + className}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 


### PR DESCRIPTION
## Summary
- implement new `Button` component based on shadcn styles
- update `TabsTrigger` to use `Button`
- refresh `DarkModeToggle` to show sun/moon icons using `Button`

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887bcde28988324a28829a71d456ccf