### PR TITLE
Fix charts to use theme colors

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -31,7 +31,7 @@ export default function AnalysisSection() {
               <XAxis dataKey="temperature" name="Temp" unit="°C" />
               <YAxis dataKey="avgPace" name="Pace" unit="min/km" />
               <Tooltip />
-              <Scatter data={data} fill="#2563eb" />
+              <Scatter data={data} fill="hsl(var(--primary))" />
             </ScatterChart>
           </ResponsiveContainer>
         )}

--- a/frontend/src/components/RouteHeatmap.jsx
+++ b/frontend/src/components/RouteHeatmap.jsx
@@ -26,7 +26,11 @@ export default function RouteHeatmap({ coords }) {
           key={i}
           center={[p.lat, p.lon]}
           radius={4 + (8 * p.count) / max}
-          pathOptions={{ color: "#fb923c", fillColor: "#fb923c", fillOpacity: 0.6 }}
+          pathOptions={{
+            color: "hsl(var(--accent))",
+            fillColor: "hsl(var(--accent))",
+            fillOpacity: 0.6,
+          }}
         />
       ))}
     </MapContainer>

--- a/frontend/src/components/TrackMap.jsx
+++ b/frontend/src/components/TrackMap.jsx
@@ -48,11 +48,11 @@ export default function TrackMap({ points, center }) {
     if (i === 0) continue;
     const prev = points[i - 1];
     const t = curr.temperature;
-    let color = "#2563eb";
+    let color = "hsl(var(--primary))";
     if (t !== undefined && t !== null) {
-      if (t < 10) color = "#60a5fa"; // blue for cold
-      else if (t < 20) color = "#10b981"; // green for mild
-      else color = "#ef4444"; // red for warm
+      if (t < 10) color = "hsl(var(--accent))"; // blue for cold
+      else if (t < 20) color = "hsl(var(--secondary))"; // green for mild
+      else color = "hsl(var(--destructive))"; // red for warm
     }
     segments.push(
       <Polyline

--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -57,7 +57,7 @@ export default function TrendsSection() {
                   <XAxis dataKey="timestamp" tick={false} />
                   <YAxis />
                   <Tooltip />
-                  <Line type="monotone" dataKey="value" stroke="#3b82f6" dot={false} />
+                  <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" dot={false} />
                 </LineChart>
               </ResponsiveContainer>
             )}
@@ -84,7 +84,7 @@ export default function TrendsSection() {
                   <XAxis dataKey="timestamp" tick={false} />
                   <YAxis />
                   <Tooltip />
-                  <Line type="monotone" dataKey="value" stroke="#ef4444" dot={false} />
+                  <Line type="monotone" dataKey="value" stroke="hsl(var(--destructive))" dot={false} />
                 </LineChart>
               </ResponsiveContainer>
             )}


### PR DESCRIPTION
## Summary
- replace inline hex colors with theme-aware CSS variables

## Testing
- `pytest -q` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6887be93453083248d14becb9e9f78fb