### PR TITLE
Replace ProgressRing with animated RadialBarChart

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -25,9 +25,9 @@ export default function KPIGrid() {
         const lastSleep = sleep[sleep.length - 1]?.value ?? 0;
 
         setItems([
-          { label: "Steps", value: latestSteps, goal: 10000 },
-          { label: "Sleep", value: lastSleep, goal: 8 },
-          { label: "HR Avg", value: avgHr, goal: 100 },
+          { label: "Steps", value: latestSteps, goal: 10000, unit: "" },
+          { label: "Sleep", value: lastSleep, goal: 8, unit: "h" },
+          { label: "HR Avg", value: avgHr, goal: 100, unit: "bpm" },
         ]);
       } catch (err) {
         setError("Failed to load metrics");
@@ -57,7 +57,7 @@ export default function KPIGrid() {
               <CardTitle>{item.label}</CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-center h-32">
-              <ProgressRing value={item.value} max={item.goal} size={80} />
+              <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -1,31 +1,53 @@
 import React from "react";
+import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
 
-export default function ProgressRing({ value = 0, max = 100, size = 40, stroke = 4, className = "" }) {
-  const radius = (size - stroke) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const offset = circumference - (value / max) * circumference;
+export default function ProgressRing({
+  value = 0,
+  max = 100,
+  size = 40,
+  unit = "",
+  className = "",
+}) {
+  const percent = Math.max(0, Math.min(1, value / max)) * 100;
+  const data = [{ name: "progress", value: percent }];
+  const gradientId = React.useId();
+
   return (
-    <svg width={size} height={size} className={className}>
-      <circle
-        className="text-muted-foreground opacity-20"
-        stroke="currentColor"
-        fill="transparent"
-        strokeWidth={stroke}
-        cx={size / 2}
-        cy={size / 2}
-        r={radius}
-      />
-      <circle
-        className="text-primary transition-[stroke-dashoffset] duration-500 ease-out"
-        stroke="currentColor"
-        fill="transparent"
-        strokeWidth={stroke}
-        strokeDasharray={circumference}
-        strokeDashoffset={offset}
-        cx={size / 2}
-        cy={size / 2}
-        r={radius}
-      />
-    </svg>
+    <div className={"relative " + className} style={{ width: size, height: size }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RadialBarChart
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius="70%"
+          outerRadius="100%"
+          startAngle={90}
+          endAngle={-270}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="hsl(var(--accent))" />
+              <stop offset="100%" stopColor="hsl(var(--primary))" />
+            </linearGradient>
+          </defs>
+          <RadialBar
+            background
+            dataKey="value"
+            minAngle={15}
+            clockWise
+            cornerRadius={9999}
+            fill={`url(#${gradientId})`}
+            isAnimationActive
+            animationDuration={500}
+          />
+        </RadialBarChart>
+      </ResponsiveContainer>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-xl font-bold leading-none">{value}</span>
+        {unit && (
+          <span className="text-xs text-muted-foreground">{unit}</span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
+++ b/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
@@ -1,12 +1,33 @@
 import { render } from '@testing-library/react';
 import ProgressRing from '../ProgressRing';
 
-it('renders two circles and applies correct offset', () => {
-  const { container } = render(<ProgressRing value={50} max={100} size={100} stroke={10} />);
-  const circles = container.querySelectorAll('circle');
-  expect(circles).toHaveLength(2);
-  const radius = (100 - 10) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const expectedOffset = circumference - (50 / 100) * circumference;
-  expect(parseFloat(circles[1].getAttribute('stroke-dashoffset'))).toBeCloseTo(expectedOffset);
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 80, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 80,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 80,
+  });
+});
+
+it('renders radial bar chart and displays value', () => {
+  const { container, getByText } = render(
+    <ProgressRing value={50} max={100} size={80} />
+  );
+  // An svg element should be rendered for the chart
+  expect(container.querySelector('svg')).toBeInTheDocument();
+  // The numeric value should appear in the overlay
+  expect(getByText('50')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- swap SVG ProgressRing for recharts RadialBarChart
- show value & unit overlay in center
- add gradient fill and mount animation
- adjust KPIGrid to pass units
- update tests for new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887cb8a74788324bef4999a10c2fc26