### PR TITLE
Add gradient area charts with goals

### DIFF
--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -2,13 +2,15 @@ import React from "react";
 import ChartCard from "./ChartCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
 import {
-  LineChart,
-  Line,
+  AreaChart,
+  Area,
   CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
+  ReferenceLine,
+  Brush,
 } from "recharts";
 import { fetchSteps, fetchHeartrate } from "../api";
 
@@ -19,6 +21,8 @@ export default function TrendsSection() {
   const [loadingHr, setLoadingHr] = React.useState(true);
   const [errorSteps, setErrorSteps] = React.useState(null);
   const [errorHr, setErrorHr] = React.useState(null);
+  const stepsGradientId = React.useId();
+  const hrGradientId = React.useId();
 
   React.useEffect(() => {
     fetchSteps()
@@ -52,13 +56,21 @@ export default function TrendsSection() {
             )}
             {!loadingSteps && !errorSteps && (
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                  <defs>
+                    <linearGradient id={stepsGradientId} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
+                      <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.2} />
+                    </linearGradient>
+                  </defs>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="timestamp" tick={false} />
                   <YAxis />
                   <Tooltip />
-                  <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" dot={false} />
-                </LineChart>
+                  <ReferenceLine y={10000} stroke="hsl(var(--primary))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
+                  <Area type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill={`url(#${stepsGradientId})`} dot={false} />
+                  <Brush dataKey="timestamp" height={20} travellerWidth={10} />
+                </AreaChart>
               </ResponsiveContainer>
             )}
           </div>
@@ -79,13 +91,21 @@ export default function TrendsSection() {
             )}
             {!loadingHr && !errorHr && (
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={hr} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                <AreaChart data={hr} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                  <defs>
+                    <linearGradient id={hrGradientId} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
+                      <stop offset="100%" stopColor="hsl(var(--destructive))" stopOpacity={0.2} />
+                    </linearGradient>
+                  </defs>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis dataKey="timestamp" tick={false} />
                   <YAxis />
                   <Tooltip />
-                  <Line type="monotone" dataKey="value" stroke="hsl(var(--destructive))" dot={false} />
-                </LineChart>
+                  <ReferenceLine y={100} stroke="hsl(var(--destructive))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
+                  <Area type="monotone" dataKey="value" stroke="hsl(var(--destructive))" fill={`url(#${hrGradientId})`} dot={false} />
+                  <Brush dataKey="timestamp" height={20} travellerWidth={10} />
+                </AreaChart>
               </ResponsiveContainer>
             )}
           </div>


### PR DESCRIPTION
## Summary
- switch TrendsSection to use AreaChart
- add gradient fills via defs
- draw goal ReferenceLine
- include Brush for zoom

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887dec83fb48324906eb7d0f500b85b