### PR TITLE
Refactor trends section into modular charts

### DIFF
--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { fetchHeartrate } from "../api";
+
+export default function HRZonesBar() {
+  const [zones, setZones] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+  const gradientId = React.useId();
+
+  React.useEffect(() => {
+    fetchHeartrate()
+      .then((data) => {
+        const zoneDefs = [
+          { label: "Easy", min: 0, max: 99 },
+          { label: "Fat Burn", min: 100, max: 119 },
+          { label: "Cardio", min: 120, max: 139 },
+          { label: "Peak", min: 140, max: Infinity },
+        ];
+        const counts = zoneDefs.map(() => 0);
+        for (const p of data) {
+          for (let i = 0; i < zoneDefs.length; i++) {
+            if (p.value >= zoneDefs[i].min && p.value <= zoneDefs[i].max) {
+              counts[i] += 1;
+              break;
+            }
+          }
+        }
+        setZones(
+          zoneDefs.map((z, i) => ({ zone: z.label, value: counts[i] }))
+        );
+      })
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <ChartCard title="HR Zones">
+      <div className="h-40">
+        {loading && (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Loading...
+          </div>
+        )}
+        {error && (
+          <div className="flex h-full items-center justify-center text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {!loading && !error && (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={zones} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="hsl(var(--accent))" />
+                  <stop offset="100%" stopColor="hsl(var(--destructive))" />
+                </linearGradient>
+              </defs>
+              <XAxis dataKey="zone" />
+              <YAxis allowDecimals={false} />
+              <Tooltip />
+              <Bar dataKey="value" fill={`url(#${gradientId})`} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import {
+  AreaChart,
+  Area,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Brush,
+} from "recharts";
+import { fetchSteps } from "../api";
+
+export default function StepsSparkline() {
+  const [steps, setSteps] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+  const gradientId = React.useId();
+
+  React.useEffect(() => {
+    fetchSteps()
+      .then(setSteps)
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <ChartCard title="Step Trend">
+      <div className="h-40">
+        {loading && (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Loading...
+          </div>
+        )}
+        {error && (
+          <div className="flex h-full items-center justify-center text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {!loading && !error && (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
+                  <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.2} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="timestamp" tick={false} />
+              <YAxis />
+              <Tooltip />
+              <ReferenceLine y={10000} stroke="hsl(var(--primary))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
+              <Area type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill={`url(#${gradientId})`} dot={false} />
+              <Brush dataKey="timestamp" height={20} travellerWidth={10} />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -1,116 +1,12 @@
 import React from "react";
-import ChartCard from "./ChartCard";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
-import {
-  AreaChart,
-  Area,
-  CartesianGrid,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  ReferenceLine,
-  Brush,
-} from "recharts";
-import { fetchSteps, fetchHeartrate } from "../api";
+import StepsSparkline from "./StepsSparkline";
+import HRZonesBar from "./HRZonesBar";
 
 export default function TrendsSection() {
-  const [steps, setSteps] = React.useState([]);
-  const [hr, setHr] = React.useState([]);
-  const [loadingSteps, setLoadingSteps] = React.useState(true);
-  const [loadingHr, setLoadingHr] = React.useState(true);
-  const [errorSteps, setErrorSteps] = React.useState(null);
-  const [errorHr, setErrorHr] = React.useState(null);
-  const stepsGradientId = React.useId();
-  const hrGradientId = React.useId();
-
-  React.useEffect(() => {
-    fetchSteps()
-      .then(setSteps)
-      .catch(() => setErrorSteps("Failed to load"))
-      .finally(() => setLoadingSteps(false));
-    fetchHeartrate()
-      .then(setHr)
-      .catch(() => setErrorHr("Failed to load"))
-      .finally(() => setLoadingHr(false));
-  }, []);
-
   return (
-    <Tabs defaultValue="steps" className="space-y-4">
-      <TabsList>
-        <TabsTrigger value="steps">Steps</TabsTrigger>
-        <TabsTrigger value="heartrate">Heart Rate</TabsTrigger>
-      </TabsList>
-      <TabsContent value="steps">
-        <ChartCard title="Step Trend">
-          <div className="h-40">
-            {loadingSteps && (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Loading...
-              </div>
-            )}
-            {errorSteps && (
-              <div className="flex h-full items-center justify-center text-sm text-destructive">
-                {errorSteps}
-              </div>
-            )}
-            {!loadingSteps && !errorSteps && (
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-                  <defs>
-                    <linearGradient id={stepsGradientId} x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
-                      <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.2} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="timestamp" tick={false} />
-                  <YAxis />
-                  <Tooltip />
-                  <ReferenceLine y={10000} stroke="hsl(var(--primary))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
-                  <Area type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill={`url(#${stepsGradientId})`} dot={false} />
-                  <Brush dataKey="timestamp" height={20} travellerWidth={10} />
-                </AreaChart>
-              </ResponsiveContainer>
-            )}
-          </div>
-        </ChartCard>
-      </TabsContent>
-      <TabsContent value="heartrate">
-        <ChartCard title="Heart Rate Trend">
-          <div className="h-40">
-            {loadingHr && (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Loading...
-              </div>
-            )}
-            {errorHr && (
-              <div className="flex h-full items-center justify-center text-sm text-destructive">
-                {errorHr}
-              </div>
-            )}
-            {!loadingHr && !errorHr && (
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={hr} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-                  <defs>
-                    <linearGradient id={hrGradientId} x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
-                      <stop offset="100%" stopColor="hsl(var(--destructive))" stopOpacity={0.2} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="timestamp" tick={false} />
-                  <YAxis />
-                  <Tooltip />
-                  <ReferenceLine y={100} stroke="hsl(var(--destructive))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
-                  <Area type="monotone" dataKey="value" stroke="hsl(var(--destructive))" fill={`url(#${hrGradientId})`} dot={false} />
-                  <Brush dataKey="timestamp" height={20} travellerWidth={10} />
-                </AreaChart>
-              </ResponsiveContainer>
-            )}
-          </div>
-        </ChartCard>
-      </TabsContent>
-    </Tabs>
+    <div className="grid gap-4 sm:grid-cols-2">
+      <StepsSparkline />
+      <HRZonesBar />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract `StepsSparkline` and `HRZonesBar` from TrendsSection
- simplify `TrendsSection` to render both charts side by side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887eba801548324b8a6ad3987e5f7ee