### PR TITLE
Add calendar heatmap for daily totals

### DIFF
--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { fetchDailyTotals } from "../api";
+
+export default function CalendarHeatmap() {
+  const [data, setData] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchDailyTotals()
+      .then(setData)
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">Loading...</div>;
+  }
+  if (error) {
+    return <div className="text-sm text-destructive">{error}</div>;
+  }
+  if (!data.length) {
+    return <div className="text-sm text-muted-foreground">No data</div>;
+  }
+
+  const max = Math.max(...data.map((d) => d.distance));
+
+  return (
+    <div className="grid grid-cols-7 gap-1 text-xs">
+      {data.map((d) => {
+        const intensity = d.distance / max;
+        let color = "bg-green-200";
+        if (intensity > 0.66) color = "bg-green-600";
+        else if (intensity > 0.33) color = "bg-green-400";
+        const title = `${d.date} - ${(d.distance / 1000).toFixed(1)} km, ${(
+          d.duration / 60
+        ).toFixed(0)} min`;
+        return (
+          <div
+            key={d.date}
+            className={`h-4 w-4 rounded ${color}`}
+            title={title}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ChartCard from "./ChartCard";
 import ActivityCalendar from "./ActivityCalendar";
+import CalendarHeatmap from "./CalendarHeatmap";
 import { Card, CardContent } from "./ui/Card";
 import { fetchActivityTrack, fetchRoutes } from "../api";
 const LazyMap = React.lazy(() => import("./LeafletMap"));
@@ -77,6 +78,9 @@ export default function MapSection() {
             </CardContent>
           </Card>
         </div>
+      </ChartCard>
+      <ChartCard title="On This Day">
+        <CalendarHeatmap />
       </ChartCard>
       <ChartCard title="Route Heatmap">
         <div className="mb-2 flex flex-col gap-2 sm:flex-row">

--- a/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
+++ b/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import CalendarHeatmap from '../CalendarHeatmap';
+import { vi } from 'vitest';
+
+it('renders squares with tooltip text', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        { date: '2023-01-01', distance: 5000, duration: 1800 },
+        { date: '2023-01-02', distance: 6000, duration: 1900 },
+      ]),
+  });
+
+  render(<CalendarHeatmap />);
+  const square = await screen.findByTitle(/2023-01-01/);
+  expect(square.getAttribute('title')).toMatch('2023-01-01');
+  expect(await screen.findAllByTitle(/2023-01-0[12]/)).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary
- implement `CalendarHeatmap` component to display daily distance totals
- show tooltip with date, distance and duration
- add "On This Day" card in `MapSection`
- test new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887f4d073248324a45c727c7a1f363c