### PR TITLE
Add weather overlay and elevation profile

### DIFF
--- a/backend/app/garmin_client.py
+++ b/backend/app/garmin_client.py
@@ -143,6 +143,7 @@ class GarminClient:
                             "timestamp": ts,
                             "lat": lat + i * 0.001,
                             "lon": lon + i * 0.001,
+                            "elevation": 260 + random.uniform(-5, 5),
                             "heartRate": random.randint(60, 170),
                             "speed": round(random.uniform(2.5, 6.0), 2),
                         }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -169,6 +169,7 @@ async def activity_track(activity_id: str):
                         "timestamp": ts,
                         "lat": lat + i * 0.001,
                         "lon": lon + i * 0.001,
+                        "elevation": 260 + random.uniform(-5, 5),
                         "heartRate": random.randint(60, 170),
                         "speed": round(random.uniform(2.5, 6.0), 2),
                     })
@@ -179,6 +180,8 @@ async def activity_track(activity_id: str):
     if points:
         weather = get_weather(points[0]["lat"], points[0]["lon"], points[0]["timestamp"])
         for p in points:
+            if "elevation" not in p:
+                p["elevation"] = 260 + random.uniform(-5, 5)
             p["temperature"] = weather.get("temperature")
             p["precipitation"] = weather.get("precipitation")
             p["windspeed"] = weather.get("windspeed")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -87,6 +87,7 @@ def test_activity_track():
     assert isinstance(data, list)
     assert data and 'timestamp' in data[0] and 'lat' in data[0] and 'lon' in data[0]
     assert 'heartRate' in data[0] and 'speed' in data[0]
+    assert 'elevation' in data[0]
     assert 'temperature' in data[0] and 'precipitation' in data[0]
     assert 'windspeed' in data[0] and 'humidity' in data[0]
 

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceDot,
+  CartesianGrid,
+} from "recharts";
+
+function haversine(lat1, lon1, lat2, lon2) {
+  const R = 6371000; // meters
+  const toRad = (v) => (v * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export default function ElevationChart({ points = [], activeIndex = null }) {
+  if (!points.length) return null;
+  const data = [];
+  let dist = 0;
+  for (let i = 0; i < points.length; i++) {
+    if (i > 0) {
+      dist += haversine(
+        points[i - 1].lat,
+        points[i - 1].lon,
+        points[i].lat,
+        points[i].lon
+      );
+    }
+    data.push({
+      dist: +(dist / 1000).toFixed(2),
+      elevation: points[i].elevation ?? 0,
+    });
+  }
+
+  return (
+    <ChartCard title="Elevation Profile">
+      <div className="h-40">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="dist" unit="km" />
+            <YAxis dataKey="elevation" unit="m" />
+            <Tooltip />
+            <Line type="monotone" dataKey="elevation" stroke="hsl(var(--primary))" dot={false} />
+            {activeIndex !== null && data[activeIndex] && (
+              <ReferenceDot
+                x={data[activeIndex].dist}
+                y={data[activeIndex].elevation}
+                r={4}
+                fill="hsl(var(--accent))"
+                stroke="none"
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/LeafletMap.jsx
+++ b/frontend/src/components/LeafletMap.jsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { MapContainer, TileLayer, Polyline } from "react-leaflet";
+import { MapContainer, TileLayer, Polyline, CircleMarker } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 
-export default function LeafletMap({ points, metricKey = "heartRate" }) {
+export default function LeafletMap({
+  points,
+  metricKey = "heartRate",
+  showWeather = false,
+  onHoverPoint,
+}) {
   if (!points.length) return null;
   const center = [points[0].lat, points[0].lon];
 
@@ -28,10 +33,27 @@ export default function LeafletMap({ points, metricKey = "heartRate" }) {
           [prev.lat, prev.lon],
           [curr.lat, curr.lon],
         ]}
-        color={color}
+        pathOptions={{ color }}
+        eventHandlers={{
+          mouseover: () => onHoverPoint && onHoverPoint(i),
+          mouseout: () => onHoverPoint && onHoverPoint(null),
+        }}
       />
     );
   }
+
+  const markers = points.map((p, idx) => (
+    <CircleMarker
+      key={`pt-${idx}`}
+      center={[p.lat, p.lon]}
+      radius={2}
+      pathOptions={{ opacity: 0, fillOpacity: 0 }}
+      eventHandlers={{
+        mouseover: () => onHoverPoint && onHoverPoint(idx),
+        mouseout: () => onHoverPoint && onHoverPoint(null),
+      }}
+    />
+  ));
 
   return (
     <MapContainer center={center} zoom={13} style={{ height: "100%", width: "100%" }}>
@@ -39,7 +61,14 @@ export default function LeafletMap({ points, metricKey = "heartRate" }) {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution="&copy; OpenStreetMap contributors"
       />
+      {showWeather && (
+        <TileLayer
+          url="https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=439d4b804bc8187953eb36d2a8c26a02"
+          attribution="&copy; <a href='https://openweathermap.org/'>OpenWeatherMap</a>"
+        />
+      )}
       {segments}
+      {markers}
     </MapContainer>
   );
 }

--- a/frontend/src/components/__tests__/ElevationChart.test.jsx
+++ b/frontend/src/components/__tests__/ElevationChart.test.jsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import ElevationChart from '../ElevationChart';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 100, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+const points = [
+  { lat: 0, lon: 0, elevation: 100 },
+  { lat: 0, lon: 1, elevation: 110 },
+  { lat: 0, lon: 2, elevation: 120 },
+];
+
+test('renders reference dot when active index provided', () => {
+  const { container } = render(
+    <ElevationChart points={points} activeIndex={1} />
+  );
+  // ReferenceDot renders a circle element
+  expect(container.querySelector('circle')).toBeInTheDocument();
+});

--- a/frontend/src/components/__tests__/LeafletMap.test.jsx
+++ b/frontend/src/components/__tests__/LeafletMap.test.jsx
@@ -5,7 +5,10 @@ import { vi } from 'vitest';
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children }) => <div>{children}</div>,
   TileLayer: () => null,
-  Polyline: ({ color }) => <div data-testid="polyline" data-color={color} />,
+  Polyline: ({ pathOptions }) => (
+    <div data-testid="polyline" data-color={pathOptions.color} />
+  ),
+  CircleMarker: () => null,
 }));
 
 delete window.L; // ensure no Leaflet global


### PR DESCRIPTION
## Summary
- color map segments by metric and expose hover events
- include optional weather tile layer on Leaflet map
- track hover index from map section and show elevation profile
- generate dummy elevation values in backend track data
- test coverage for new elevation chart and map updates

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887fa954f108324a136b21c34400fc6