### PR TITLE
Add UI polish with skeletons and custom tooltips

### DIFF
--- a/frontend/src/components/ActivityCalendar.jsx
+++ b/frontend/src/components/ActivityCalendar.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fetchActivitiesByDate } from "../api";
+import Skeleton from "./ui/Skeleton";
 
 export default function ActivityCalendar({ onSelect }) {
   const [days, setDays] = React.useState({});
@@ -14,7 +15,7 @@ export default function ActivityCalendar({ onSelect }) {
   }, []);
 
   if (loading) {
-    return <div className="text-sm text-muted-foreground">Loading...</div>;
+    return <Skeleton className="h-40 w-full" />;
   }
   if (error) {
     return <div className="text-sm text-destructive">{error}</div>;
@@ -53,7 +54,7 @@ export default function ActivityCalendar({ onSelect }) {
             <button
               key={date}
               onClick={() => onSelect(acts[0])}
-              className="rounded-md bg-muted px-2 py-1 hover:bg-muted/70"
+              className="rounded-md bg-muted px-2 py-1 transition-transform hover:scale-105 focus:scale-105 hover:bg-muted/70 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
             >
               {dayNum}
             </button>

--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -2,6 +2,24 @@ import React from "react";
 import ChartCard from "./ChartCard";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchAnalysis } from "../api";
+import Skeleton from "./ui/Skeleton";
+
+function AnalysisTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const { temperature, avgPace } = payload[0].payload;
+  return (
+    <div className="rounded bg-background p-2 text-sm shadow">
+      <div className="flex items-center gap-1">
+        <span>🌡️</span>
+        <span>{temperature}°C</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <span>⏱</span>
+        <span>{avgPace} min/km</span>
+      </div>
+    </div>
+  );
+}
 
 export default function AnalysisSection() {
   const [data, setData] = React.useState([]);
@@ -18,9 +36,7 @@ export default function AnalysisSection() {
   return (
     <ChartCard title="Pace vs Temperature">
       <div className="h-64">
-        {loading && (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Loading...</div>
-        )}
+        {loading && <Skeleton className="h-full w-full" />}
         {error && (
           <div className="flex h-full items-center justify-center text-sm text-destructive">{error}</div>
         )}
@@ -30,7 +46,7 @@ export default function AnalysisSection() {
               <CartesianGrid />
               <XAxis dataKey="temperature" name="Temp" unit="°C" />
               <YAxis dataKey="avgPace" name="Pace" unit="min/km" />
-              <Tooltip />
+              <Tooltip content={<AnalysisTooltip />} />
               <Scatter data={data} fill="hsl(var(--primary))" />
             </ScatterChart>
           </ResponsiveContainer>

--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fetchDailyTotals } from "../api";
+import Skeleton from "./ui/Skeleton";
 
 export default function CalendarHeatmap() {
   const [data, setData] = React.useState([]);
@@ -14,7 +15,7 @@ export default function CalendarHeatmap() {
   }, []);
 
   if (loading) {
-    return <div className="text-sm text-muted-foreground">Loading...</div>;
+    return <Skeleton className="h-20 w-full" />;
   }
   if (error) {
     return <div className="text-sm text-destructive">{error}</div>;
@@ -38,7 +39,7 @@ export default function CalendarHeatmap() {
         return (
           <div
             key={d.date}
-            className={`h-4 w-4 rounded ${color}`}
+            className={`h-4 w-4 rounded ${color} transition-transform hover:scale-110 focus:scale-110`}
             title={title}
           />
         );

--- a/frontend/src/components/DailyHeatmap.jsx
+++ b/frontend/src/components/DailyHeatmap.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fetchDailyTotals } from "../api";
+import Skeleton from "./ui/Skeleton";
 
 export default function DailyHeatmap() {
   const [data, setData] = React.useState([]);
@@ -14,7 +15,7 @@ export default function DailyHeatmap() {
   }, []);
 
   if (loading) {
-    return <div className="text-sm text-muted-foreground">Loading...</div>;
+    return <Skeleton className="h-20 w-full" />;
   }
   if (error) {
     return <div className="text-sm text-destructive">{error}</div>;
@@ -33,7 +34,7 @@ export default function DailyHeatmap() {
         return (
           <div
             key={d.date}
-            className={`h-4 w-4 rounded ${color}`}
+            className={`h-4 w-4 rounded ${color} transition-transform hover:scale-110 focus:scale-110`}
             title={`${d.date} - ${(d.distance / 1000).toFixed(1)} km`}
           />
         );

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -11,6 +11,20 @@ import {
   CartesianGrid,
 } from "recharts";
 
+function ElevationTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const { dist, elevation } = payload[0].payload;
+  return (
+    <div className="rounded bg-background p-2 text-sm shadow">
+      <div className="flex items-center gap-1">
+        <span>⛰️</span>
+        <span>{elevation.toFixed(0)} m</span>
+      </div>
+      <div className="text-xs text-muted-foreground">at {dist.toFixed(2)} km</div>
+    </div>
+  );
+}
+
 function haversine(lat1, lon1, lat2, lon2) {
   const R = 6371000; // meters
   const toRad = (v) => (v * Math.PI) / 180;
@@ -53,7 +67,7 @@ export default function ElevationChart({ points = [], activeIndex = null }) {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="dist" unit="km" />
             <YAxis dataKey="elevation" unit="m" />
-            <Tooltip />
+            <Tooltip content={<ElevationTooltip />} />
             <Line type="monotone" dataKey="elevation" stroke="hsl(var(--primary))" dot={false} />
             {activeIndex !== null && data[activeIndex] && (
               <ReferenceDot

--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -9,6 +9,21 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { fetchHeartrate } from "../api";
+import Skeleton from "./ui/Skeleton";
+
+function ZoneTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const { zone, value } = payload[0].payload;
+  return (
+    <div className="rounded bg-background p-2 text-sm shadow">
+      <div>{zone}</div>
+      <div className="flex items-center gap-1">
+        <span>❤️</span>
+        <span>{value} samples</span>
+      </div>
+    </div>
+  );
+}
 
 export default function HRZonesBar() {
   const [zones, setZones] = React.useState([]);
@@ -45,11 +60,7 @@ export default function HRZonesBar() {
   return (
     <ChartCard title="HR Zones">
       <div className="h-40">
-        {loading && (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Loading...
-          </div>
-        )}
+        {loading && <Skeleton className="h-full w-full" />}
         {error && (
           <div className="flex h-full items-center justify-center text-sm text-destructive">
             {error}
@@ -66,7 +77,7 @@ export default function HRZonesBar() {
               </defs>
               <XAxis dataKey="zone" />
               <YAxis allowDecimals={false} />
-              <Tooltip />
+              <Tooltip content={<ZoneTooltip />} />
               <Bar dataKey="value" fill={`url(#${gradientId})`} />
             </BarChart>
           </ResponsiveContainer>

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
 import ProgressRing from "./ui/ProgressRing";
 import { fetchHeartrate, fetchSleep, fetchSteps } from "../api";
+import Skeleton from "./ui/Skeleton";
 
 export default function KPIGrid() {
   const [items, setItems] = React.useState([]);
@@ -42,11 +43,19 @@ export default function KPIGrid() {
 
   return (
     <div className="grid gap-4 sm:grid-cols-3">
-      {loading && (
-        <div className="col-span-3 text-center text-sm text-muted-foreground">
-          Loading...
-        </div>
-      )}
+      {loading &&
+        Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardHeader>
+              <CardTitle>
+                <Skeleton className="h-6 w-24" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex h-32 items-center justify-center">
+              <Skeleton className="h-20 w-20 rounded-full" />
+            </CardContent>
+          </Card>
+        ))}
       {error && (
         <div className="col-span-3 text-center text-sm text-destructive">{error}</div>
       )}

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -11,7 +11,23 @@ import {
   ReferenceLine,
   Brush,
 } from "recharts";
+import Skeleton from "./ui/Skeleton";
 import { fetchSteps } from "../api";
+
+function StepTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0].value;
+  const date = label.split("T")[0];
+  return (
+    <div className="rounded bg-background p-2 text-sm shadow">
+      <div>{date}</div>
+      <div className="flex items-center gap-1">
+        <span>🚶</span>
+        <span>{value} steps</span>
+      </div>
+    </div>
+  );
+}
 
 export default function StepsSparkline() {
   const [steps, setSteps] = React.useState([]);
@@ -29,11 +45,7 @@ export default function StepsSparkline() {
   return (
     <ChartCard title="Step Trend">
       <div className="h-40">
-        {loading && (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Loading...
-          </div>
-        )}
+        {loading && <Skeleton className="h-full w-full" />}
         {error && (
           <div className="flex h-full items-center justify-center text-sm text-destructive">
             {error}
@@ -51,7 +63,7 @@ export default function StepsSparkline() {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="timestamp" tick={false} />
               <YAxis />
-              <Tooltip />
+              <Tooltip content={<StepTooltip />} />
               <ReferenceLine y={10000} stroke="hsl(var(--primary))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
               <Area type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill={`url(#${gradientId})`} dot={false} />
               <Brush dataKey="timestamp" height={20} travellerWidth={10} />

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -2,7 +2,12 @@ import React from "react";
 
 export function Card({ className = "", children }) {
   return (
-    <div className={"rounded-lg border bg-card text-card-foreground shadow-sm " + className}>
+    <div
+      className={
+        "rounded-lg border bg-card text-card-foreground shadow-sm transition-shadow hover:shadow-md focus-within:shadow-md " +
+        className
+      }
+    >
       {children}
     </div>
   );

--- a/frontend/src/components/ui/Skeleton.jsx
+++ b/frontend/src/components/ui/Skeleton.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function Skeleton({ className = "" }) {
+  return (
+    <div className={"animate-pulse rounded-md bg-muted " + className} />
+  );
+}


### PR DESCRIPTION
## Summary
- add `Skeleton` UI component for loading states
- show skeletons while fetching KPI and chart data
- enhance charts with icon-based tooltips showing units
- animate cards and heatmap squares on hover/focus

## Testing
- `npm run test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887fd8778b083249fea5cde9339da5a