### PR TITLE
Add weekly summary card with sparklines

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,14 +1,7 @@
 import React from "react";
-import { Card, CardHeader, CardTitle } from "./ui/Card";
+import WeeklySummaryCard from "./WeeklySummaryCard";
 import DarkModeToggle from "./DarkModeToggle";
 
 export default function Header() {
-  return (
-    <Card className="mb-4">
-      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <CardTitle>Garmin Activity Dashboard</CardTitle>
-        <DarkModeToggle />
-      </CardHeader>
-    </Card>
-  );
+  return <WeeklySummaryCard><DarkModeToggle /></WeeklySummaryCard>;
 }


### PR DESCRIPTION
## Summary
- add `WeeklySummaryCard` component
- use the new card in `Header`
- include miniature Recharts sparklines for steps and sleep

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688802e4e2808324aa146d1dace7858f