### PR TITLE
Add two-tone palette and animation

### DIFF
--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -30,9 +30,9 @@ export default function CalendarHeatmap() {
     <div className="grid grid-cols-7 gap-1 text-xs">
       {data.map((d) => {
         const intensity = d.distance / max;
-        let color = "bg-green-200";
-        if (intensity > 0.66) color = "bg-green-600";
-        else if (intensity > 0.33) color = "bg-green-400";
+        let color = "bg-tone-light";
+        if (intensity > 0.66) color = "bg-tone-dark";
+        else if (intensity > 0.33) color = "bg-tone-dark/60";
         const title = `${d.date} - ${(d.distance / 1000).toFixed(1)} km, ${(
           d.duration / 60
         ).toFixed(0)} min`;

--- a/frontend/src/components/ChartCard.jsx
+++ b/frontend/src/components/ChartCard.jsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
 
 export default function ChartCard({ title, children }) {
   return (
-    <Card>
+    <Card className="animate-in fade-in">
       <CardHeader>
         <CardTitle>{title}</CardTitle>
       </CardHeader>

--- a/frontend/src/components/DailyHeatmap.jsx
+++ b/frontend/src/components/DailyHeatmap.jsx
@@ -28,9 +28,9 @@ export default function DailyHeatmap() {
     <div className="grid grid-cols-7 gap-1 text-xs">
       {data.map((d) => {
         const intensity = d.distance / max;
-        let color = "bg-green-200";
-        if (intensity > 0.66) color = "bg-green-600";
-        else if (intensity > 0.33) color = "bg-green-400";
+        let color = "bg-tone-light";
+        if (intensity > 0.66) color = "bg-tone-dark";
+        else if (intensity > 0.33) color = "bg-tone-dark/60";
         return (
           <div
             key={d.date}

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -31,7 +31,7 @@ export default function WeeklySummaryCard({ children }) {
   const totalDistanceKm = totals.reduce((sum, p) => sum + p.distance, 0) / 1000;
 
   return (
-    <Card className="mb-4">
+    <Card className="mb-4 animate-in fade-in">
       <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1">
           {loading && <Skeleton className="h-6 w-32" />}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,6 +18,10 @@ module.exports = {
           DEFAULT: "#02343F",
           foreground: "#F0EDCC",
         },
+        tone: {
+          light: "#F0EDCC",
+          dark: "#02343F",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- define two tone color palette in Tailwind config
- switch heatmaps to use palette classes
- add fade‐in animation to chart cards

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688806afca5883249fa7d9ef5588ab20