### PR TITLE
Fix redundant CSS import

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,8 +4,7 @@
 /* 2) Component layer (you can add your own here after) */
 @tailwind components;
 
-/* 3) shadcn/ui\u2019s built-in component styles */
-@import 'tailwindcss-shadcn-ui/style.css';
+/* 3) shadcn/ui's built-in component styles load automatically via the preset */
 
 /* 4) Utility layer */
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- remove direct import of shadcn UI CSS
- run frontend tests and build

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68880d4c30788324835238e915977d77