### PR TITLE
Add ThemeProvider and CSS variable dark mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <script>
+    (function() {
+      const ls = localStorage.theme;
+      const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = ls === 'dark' || (!ls && prefers) ? 'dark' : 'light';
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+    })();
+  </script>
+  <link rel="stylesheet" href="/src/index.css" />
   <title>Garmin Activity Dashboard</title>
 </head>
 <body>

--- a/frontend/src/ThemeContext.jsx
+++ b/frontend/src/ThemeContext.jsx
@@ -1,0 +1,27 @@
+import React, { createContext, useEffect, useState } from 'react';
+
+export const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/frontend/src/components/DarkModeToggle.jsx
+++ b/frontend/src/components/DarkModeToggle.jsx
@@ -1,24 +1,13 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Button } from "./ui/Button";
+import { ThemeContext } from "../ThemeContext";
 
 export default function DarkModeToggle() {
-  const [enabled, setEnabled] = React.useState(false);
-
-  React.useEffect(() => {
-    const stored = localStorage.getItem("darkMode");
-    const prefers =
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const initial = stored === null ? prefers : stored === "true";
-    setEnabled(initial);
-    if (initial) document.documentElement.classList.add("dark");
-  }, []);
+  const { theme, setTheme } = useContext(ThemeContext);
+  const enabled = theme === "dark";
 
   const toggle = () => {
-    const next = !enabled;
-    setEnabled(next);
-    localStorage.setItem("darkMode", next);
-    document.documentElement.classList.toggle("dark", next);
+    setTheme(enabled ? "light" : "dark");
   };
 
   const SunIcon = (

--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -30,6 +30,9 @@ export default function HRZonesBar() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
   const gradientId = React.useId();
+  const styles = getComputedStyle(document.documentElement);
+  const accent = styles.getPropertyValue('--color-accent').trim();
+  const destructive = styles.getPropertyValue('--destructive').trim();
 
   React.useEffect(() => {
     fetchHeartrate()
@@ -71,8 +74,8 @@ export default function HRZonesBar() {
             <BarChart data={zones} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
               <defs>
                 <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="hsl(var(--accent))" />
-                  <stop offset="100%" stopColor="hsl(var(--destructive))" />
+                  <stop offset="0%" stopColor={accent} />
+                  <stop offset="100%" stopColor={destructive} />
                 </linearGradient>
               </defs>
               <XAxis dataKey="zone" />

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -34,6 +34,9 @@ export default function StepsSparkline() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
   const gradientId = React.useId();
+  const styles = getComputedStyle(document.documentElement);
+  const accent = styles.getPropertyValue('--color-accent').trim();
+  const primary = styles.getPropertyValue('--primary').trim();
 
   React.useEffect(() => {
     fetchSteps()
@@ -56,16 +59,16 @@ export default function StepsSparkline() {
             <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
               <defs>
                 <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="hsl(var(--accent))" stopOpacity={0.8} />
-                  <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0.2} />
+                  <stop offset="0%" stopColor={accent} stopOpacity={0.8} />
+                  <stop offset="100%" stopColor={primary} stopOpacity={0.2} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="timestamp" tick={false} />
               <YAxis />
               <Tooltip content={<StepTooltip />} />
-              <ReferenceLine y={10000} stroke="hsl(var(--primary))" strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
-              <Area type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill={`url(#${gradientId})`} dot={false} />
+              <ReferenceLine y={10000} stroke={primary} strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
+              <Area type="monotone" dataKey="value" stroke={primary} fill={`url(#${gradientId})`} dot={false} />
               <Brush dataKey="timestamp" height={20} travellerWidth={10} />
             </AreaChart>
           </ResponsiveContainer>

--- a/frontend/src/components/__tests__/DarkModeToggle.test.jsx
+++ b/frontend/src/components/__tests__/DarkModeToggle.test.jsx
@@ -1,9 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DarkModeToggle from '../DarkModeToggle';
+import { ThemeProvider } from '../../ThemeContext';
+
+beforeAll(() => {
+  window.matchMedia = window.matchMedia || (() => ({ matches: false, addListener: () => {}, removeListener: () => {} }));
+});
 
 it('toggles dark class on html element', async () => {
-  render(<DarkModeToggle />);
+  render(
+    <ThemeProvider>
+      <DarkModeToggle />
+    </ThemeProvider>
+  );
   const btn = screen.getByRole('button', { name: /dark/i });
   await userEvent.click(btn);
   expect(document.documentElement.classList.contains('dark')).toBe(true);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,18 @@
 
 /* 4) Utility layer */
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --color-accent: #4f46e5;
+    --color-water: #0ea5e9;
+    --color-fertilize: #16a34a;
+    --color-healthy: #15803d;
+  }
+  .dark {
+    --color-accent: #e0e7ff;
+    --color-water: #7dd3fc;
+    --color-fertilize: #6ee7b7;
+    --color-healthy: #bbf7d0;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
-import "./index.css";
+import { ThemeProvider } from "./ThemeContext";
 
-ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- handle dark mode via `.dark` class initialized in `index.html`
- implement `ThemeProvider` context and wrap app
- update `DarkModeToggle` to use the context
- expose CSS palette variables in `index.css`
- adjust charts to read CSS variables at runtime
- update tests for the new theme provider

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688815a4bd54832485dc7b538f7896a6