### PR TITLE
Add fetchRuns helper and test

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -28,4 +28,5 @@ export const fetchRoutes = (params = {}) => {
   return apiGet(`/routes${qs}`);
 };
 export const fetchDailyTotals = () => apiGet('/daily-totals');
+export const fetchRuns = () => apiGet('/runs');
 export const fetchAnalysis = () => apiGet('/analysis');

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -1,0 +1,15 @@
+import { fetchRuns } from '../../api';
+import { vi } from 'vitest';
+
+test('fetchRuns returns parsed JSON', async () => {
+  const data = [
+    { date: '2023-01-01', distance: 5000, duration: 1800 },
+  ];
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+
+  const result = await fetchRuns();
+  expect(result).toEqual(data);
+});


### PR DESCRIPTION
## Summary
- add `fetchRuns` API helper for the `/runs` endpoint
- export the new function
- test `fetchRuns` with mocked `fetch`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68881ede88608324b71f431be5050f70