### PR TITLE
Add run summary card

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@shadcn/ui": "^0.0.4",
+        "date-fns": "^3.6.0",
         "leaflet": "^1.9.4",
         "react": "^18.2.0",
         "react-calendar-heatmap": "1.9.0",
@@ -2392,6 +2393,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "react-calendar-heatmap": "1.9.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "recharts": "^3.1.0"
+    "recharts": "^3.1.0",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import KPIGrid from "./components/KPIGrid";
 import TrendsSection from "./components/TrendsSection";
 import DailyHeatmap from "./components/DailyHeatmap";
 import RunHeatmap from "./components/RunHeatmap";
+import SummaryCard from "./components/SummaryCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/Tabs";
 const MapSection = React.lazy(() => import("./components/MapSection"));
 const AnalysisSection = React.lazy(() => import("./components/AnalysisSection"));
@@ -13,6 +14,7 @@ export default function App() {
     <div className="min-h-screen bg-background text-foreground">
       <Header />
       <main className="container mx-auto space-y-6 py-6">
+        <SummaryCard />
         <Tabs defaultValue="dashboard" className="space-y-6">
           <TabsList className="mb-4">
             <TabsTrigger value="dashboard">Dashboard</TabsTrigger>

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Card, CardHeader, CardTitle } from "./ui/Card";
+import Skeleton from "./ui/Skeleton";
+import { fetchRuns } from "../api";
+import { parseISO, differenceInCalendarDays } from "date-fns";
+
+export function computeSummary(runs = []) {
+  if (!runs.length)
+    return { runCount: 0, totalDistance: 0, totalDuration: 0, streak: 0 };
+
+  const runDates = Array.from(new Set(runs.map((r) => r.date))).sort((a, b) =>
+    b.localeCompare(a)
+  );
+
+  let streak = 1;
+  for (let i = 1; i < runDates.length; i++) {
+    const prev = parseISO(runDates[i - 1]);
+    const cur = parseISO(runDates[i]);
+    if (differenceInCalendarDays(prev, cur) === 1) streak++;
+    else break;
+  }
+
+  const totals = runs.reduce(
+    (acc, r) => {
+      acc.totalDistance += r.distance || 0;
+      acc.totalDuration += r.duration || 0;
+      return acc;
+    },
+    { totalDistance: 0, totalDuration: 0 }
+  );
+
+  return { runCount: runs.length, streak, ...totals };
+}
+
+export default function SummaryCard() {
+  const [summary, setSummary] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchRuns()
+      .then((data) => setSummary(computeSummary(data)))
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <Card className="animate-in fade-in">
+      <CardHeader>
+        {loading && <Skeleton className="h-6 w-32" />}
+        {error && !loading && (
+          <div className="text-sm text-destructive">{error}</div>
+        )}
+        {!loading && !error && summary && (
+          <>
+            <CardTitle>Run Summary</CardTitle>
+            <div className="text-sm text-muted-foreground">
+              {summary.runCount} runs &bull;{" "}
+              {(summary.totalDistance / 1000).toFixed(1)} km &bull;{" "}
+              {summary.streak} day streak
+            </div>
+          </>
+        )}
+      </CardHeader>
+    </Card>
+  );
+}

--- a/frontend/src/components/__tests__/SummaryCard.test.jsx
+++ b/frontend/src/components/__tests__/SummaryCard.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import SummaryCard, { computeSummary } from '../SummaryCard';
+import { vi } from 'vitest';
+
+it('computeSummary totals runs and streak', () => {
+  const data = [
+    { date: '2023-01-03', distance: 1000, duration: 300 },
+    { date: '2023-01-02', distance: 2000, duration: 600 },
+    { date: '2023-01-01', distance: 3000, duration: 900 },
+  ];
+  const result = computeSummary(data);
+  expect(result.runCount).toBe(3);
+  expect(result.totalDistance).toBe(6000);
+  expect(result.totalDuration).toBe(1800);
+  expect(result.streak).toBe(3);
+});
+
+it('renders totals from API data', async () => {
+  const runs = [
+    { date: '2023-01-01', distance: 5000, duration: 1800 },
+    { date: '2023-01-02', distance: 6000, duration: 1800 },
+  ];
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(runs),
+  });
+
+  render(<SummaryCard />);
+  const km = ((5000 + 6000) / 1000).toFixed(1);
+  expect(await screen.findByText(/2 runs/)).toBeInTheDocument();
+  expect(await screen.findByText(new RegExp(`${km}`))).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show run summary above dashboard tabs
- compute streak and totals in new SummaryCard
- include tests for computeSummary and rendering
- pull runs at startup and display totals
- add date-fns dependency

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888201b9bd08324931cb830a2b8432c