### PR TITLE
Update README for runs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,24 @@ module.exports = {
 };
 ```
 
+## Runs Endpoint
+
+The backend exposes `GET /runs` to summarize run activities. Each item in the
+returned JSON array includes:
+
+- `date` – the local start date in `YYYY-MM-DD` format
+- `distance` – total distance in meters
+- `duration` – run duration in seconds
+- `elevationGain` – ascent in meters
+
+These values are generated from Garmin data when credentials are provided or
+from dummy tracks otherwise.
+
+## Summary Card
+
+The Summary Card shown at the top of the app is implemented in
+`frontend/src/components/WeeklySummaryCard.jsx`. It fetches step counts, sleep
+hours and daily totals using the API helpers and displays the aggregated values
+with two sparklines. The component is wrapped around the dark mode toggle in
+`Header.jsx`.
+


### PR DESCRIPTION
## Summary
- document `/runs` endpoint and data fields
- explain Weekly Summary Card and its source

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888203ec3b0832495258c1a3a39a0ef