### PR TITLE
Add cumulative mileage tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ clickable. Hook into the `onSelect` prop to load a track:
 <ActivityCalendar onSelect={(act) => console.log(act)} />
 ```
 
+The "Mileage" tab visualizes your cumulative distance per month in a line chart.
+
 ## Dark Mode
 
 The UI's colors are now defined with `defineTheme` from the

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import KPIGrid from "./components/KPIGrid";
 import TrendsSection from "./components/TrendsSection";
 import DailyHeatmap from "./components/DailyHeatmap";
 import RunHeatmap from "./components/RunHeatmap";
+import CumulativeChart from "./components/CumulativeChart";
 import SummaryCard from "./components/SummaryCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/Tabs";
 const MapSection = React.lazy(() => import("./components/MapSection"));
@@ -20,6 +21,7 @@ export default function App() {
             <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
             <TabsTrigger value="map">Map</TabsTrigger>
             <TabsTrigger value="analysis">Analysis</TabsTrigger>
+            <TabsTrigger value="mileage">Mileage</TabsTrigger>
           </TabsList>
           <TabsContent value="dashboard" className="space-y-6">
             <KPIGrid />
@@ -48,6 +50,9 @@ export default function App() {
             >
               <AnalysisSection />
             </React.Suspense>
+          </TabsContent>
+          <TabsContent value="mileage" className="space-y-6">
+            <CumulativeChart />
           </TabsContent>
         </Tabs>
       </main>

--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import Skeleton from "./ui/Skeleton";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { fetchDailyTotals } from "../api";
+
+export function aggregateByMonth(daily) {
+  const totals = {};
+  for (const { date, distance } of daily) {
+    const m = date.slice(0, 7);
+    totals[m] = (totals[m] || 0) + distance;
+  }
+  const months = Object.keys(totals).sort();
+  const monthlyTotals = months.map((m) => totals[m]);
+  const cumulative = [];
+  let sum = 0;
+  for (const val of monthlyTotals) {
+    sum += val;
+    cumulative.push(sum);
+  }
+  return { months, monthlyTotals, cumulative };
+}
+
+export default function CumulativeChart() {
+  const [data, setData] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchDailyTotals()
+      .then((rows) => {
+        const { months, cumulative } = aggregateByMonth(rows);
+        const chart = months.map((m, i) => ({
+          month: m,
+          cumulative: +(cumulative[i] / 1000).toFixed(2),
+        }));
+        setData(chart);
+      })
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const Dot = (props) => {
+    const { cx, cy, payload } = props;
+    return (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={3}
+        fill="hsl(var(--primary))"
+        title={`${payload.month}: ${payload.cumulative.toFixed(1)} km`}
+      />
+    );
+  };
+
+  return (
+    <ChartCard title="Mileage Over Time">
+      <div className="h-64">
+        {loading && <Skeleton className="h-full w-full" />}
+        {error && (
+          <div className="flex h-full items-center justify-center text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {!loading && !error && data.length === 0 && (
+          <div className="text-sm text-muted-foreground">No data</div>
+        )}
+        {!loading && !error && data.length > 0 && (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis unit="km" />
+              <Tooltip formatter={(v) => `${v.toFixed(1)} km`} />
+              <Line type="monotone" dataKey="cumulative" stroke="hsl(var(--primary))" dot={<Dot />} isAnimationActive={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/__tests__/CumulativeChart.test.jsx
+++ b/frontend/src/components/__tests__/CumulativeChart.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import CumulativeChart from '../CumulativeChart';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 100, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+it('renders cumulative mileage points', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        { date: '2023-01-01', distance: 1000, duration: 0 },
+        { date: '2023-01-05', distance: 2000, duration: 0 },
+        { date: '2023-02-01', distance: 3000, duration: 0 },
+      ]),
+  });
+
+  render(<CumulativeChart />);
+  const dots = await screen.findAllByTitle(/2023-(01|02)/);
+  const titles = dots.map((d) => d.getAttribute('title'));
+  expect(titles).toEqual(['2023-01: 3.0 km', '2023-02: 6.0 km']);
+});


### PR DESCRIPTION
## Summary
- add `CumulativeChart` component that groups daily totals by month and renders a cumulative mileage line chart
- expose the chart under a new "Mileage" tab
- document the new tab in README
- test monthly aggregation and rendering

## Testing
- `npm --prefix frontend test`
- `python3 -m pytest -q backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_688822222b4483249a822bb94c4e2064