### PR TITLE
Fix dark mode colors

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,22 +1,8 @@
 /* globals.css */
 
-/* 1) Light‑mode defaults */
-:root {
-  --background:         #F0EDCC;
-  --foreground:         #02343F;
-  --accent:             #02343F;
-  --accent-foreground:  #F0EDCC;
-}
+/* Theme colors come from tailwindcss-shadcn-ui's preset */
 
-/* 2) Dark‑mode overrides */
-.dark {
-  --background:         #02343F;
-  --foreground:         #F0EDCC;
-  --accent:             #F0EDCC;
-  --accent-foreground:  #02343F;
-}
-
-/* 3) Tailwind layers */
+/* Tailwind layers */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-const { createPreset } = require("tailwindcss-shadcn-ui");
+const { createPreset, defineTheme } = require("tailwindcss-shadcn-ui");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -41,6 +41,21 @@ module.exports = {
 
   // 4. Pull in the shadcn preset for extra utilities/components
   presets: [
-    createPreset(),
+    createPreset({
+      theme: defineTheme({
+        light: {
+          background: "#F0EDCC",
+          foreground: "#02343F",
+          accent: "#02343F",
+          accentForeground: "#F0EDCC",
+        },
+        dark: {
+          background: "#02343F",
+          foreground: "#F0EDCC",
+          accent: "#F0EDCC",
+          accentForeground: "#02343F",
+        },
+      }),
+    }),
   ],
 };


### PR DESCRIPTION
## Summary
- ensure the shadcn preset loads custom theme colors
- drop duplicate color variables in globals.css

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888240fa2a48324b619dcbe449ee39c