### PR TITLE
Remove unused import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import datetime
 import random
-import os
 from dotenv import load_dotenv
 from .garmin_client import GarminClient
 from .weather import get_weather


### PR DESCRIPTION
## Summary
- remove unused `os` import in the FastAPI backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882af8ac708324a9cd7524594fb325