### PR TITLE
Fix fetchActivities query string

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -30,5 +30,7 @@ export const fetchRoutes = (params = {}) => {
 export const fetchDailyTotals = () => apiGet('/daily-totals');
 export const fetchRuns = () => apiGet('/runs');
 export const fetchAnalysis = () => apiGet('/analysis');
-export const fetchActivities = (params = {}) =>
-  apiGet('/activities' + new URLSearchParams(params).toString());
+export const fetchActivities = (params = {}) => {
+  const qs = new URLSearchParams(params).toString();
+  return apiGet(`/activities${qs ? `?${qs}` : ''}`);
+};

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -1,4 +1,4 @@
-import { fetchRuns } from '../../api';
+import { fetchRuns, fetchActivities } from '../../api';
 import { vi } from 'vitest';
 
 test('fetchRuns returns parsed JSON', async () => {
@@ -12,4 +12,14 @@ test('fetchRuns returns parsed JSON', async () => {
 
   const result = await fetchRuns();
   expect(result).toEqual(data);
+});
+
+test('fetchActivities adds query string with leading ? when params provided', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve([]),
+  });
+
+  await fetchActivities({ type: 'run' });
+  expect(global.fetch).toHaveBeenCalledWith('/activities?type=run');
 });


### PR DESCRIPTION
## Summary
- ensure `fetchActivities` prefixes query params with `?`
- verify behavior with a new unit test for `/activities` endpoint

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882af4f4e8832494ebbb763e2bc42b