### PR TITLE
Add ColorBrewer heatmap palette

### DIFF
--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -30,16 +30,15 @@ export default function CalendarHeatmap() {
     <div className="grid grid-cols-7 gap-1 text-xs">
       {data.map((d) => {
         const intensity = d.distance / max;
-        let color = "bg-tone-light";
-        if (intensity > 0.66) color = "bg-tone-dark";
-        else if (intensity > 0.33) color = "bg-tone-dark/60";
-        const title = `${d.date} - ${(d.distance / 1000).toFixed(1)} km, ${(
-          d.duration / 60
-        ).toFixed(0)} min`;
+        let idx = 0;
+        if (intensity > 0.75) idx = 3;
+        else if (intensity > 0.5) idx = 2;
+        else if (intensity > 0.25) idx = 1;
+        const title = `${d.date} - ${(d.distance / 1000).toFixed(1)} km, ${(d.duration / 60).toFixed(0)} min`;
         return (
           <div
             key={d.date}
-            className={`h-4 w-4 rounded ${color} transition-transform hover:scale-110 focus:scale-110`}
+            className={`h-4 w-4 rounded transition-transform hover:scale-110 focus:scale-110 heatmap-scale-${idx}`}
             title={title}
           />
         );

--- a/frontend/src/components/DailyHeatmap.jsx
+++ b/frontend/src/components/DailyHeatmap.jsx
@@ -28,13 +28,14 @@ export default function DailyHeatmap() {
     <div className="grid grid-cols-7 gap-1 text-xs">
       {data.map((d) => {
         const intensity = d.distance / max;
-        let color = "bg-tone-light";
-        if (intensity > 0.66) color = "bg-tone-dark";
-        else if (intensity > 0.33) color = "bg-tone-dark/60";
+        let idx = 0;
+        if (intensity > 0.75) idx = 3;
+        else if (intensity > 0.5) idx = 2;
+        else if (intensity > 0.25) idx = 1;
         return (
           <div
             key={d.date}
-            className={`h-4 w-4 rounded ${color} transition-transform hover:scale-110 focus:scale-110`}
+            className={`h-4 w-4 rounded transition-transform hover:scale-110 focus:scale-110 heatmap-scale-${idx}`}
             title={`${d.date} - ${(d.distance / 1000).toFixed(1)} km`}
           />
         );

--- a/frontend/src/components/RunHeatmap.jsx
+++ b/frontend/src/components/RunHeatmap.jsx
@@ -26,6 +26,7 @@ export default function RunHeatmap() {
     count: r.distance / 1609.34,
   }));
 
+  const palette = ["heatmap-scale-0", "heatmap-scale-1", "heatmap-scale-2", "heatmap-scale-3"];
   return (
     <CalendarHeatmap
       startDate={new Date(new Date().setFullYear(new Date().getFullYear() - 1))}
@@ -38,13 +39,12 @@ export default function RunHeatmap() {
         if (!v || v.count === null || v.count === undefined) {
           return "heatmap-empty";
         }
-        return v.count > 10
-          ? "heatmap-4"
-          : v.count > 5
-          ? "heatmap-3"
-          : v.count > 2
-          ? "heatmap-2"
-          : "heatmap-1";
+        const c = v.count;
+        let idx = 0;
+        if (c > 10) idx = 3;
+        else if (c > 5) idx = 2;
+        else if (c > 2) idx = 1;
+        return palette[idx];
       }}
       tooltipDataAttrs={(v) => ({
         "data-tip": `${v.date}: ${(v.count ?? 0).toFixed(1)}\u00a0mi`,

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -21,3 +21,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ColorBrewer YlOrRd palette for heatmap intensity */
+.heatmap-scale-0 { background-color: #ffffb2; }
+.heatmap-scale-1 { background-color: #fecc5c; }
+.heatmap-scale-2 { background-color: #fd8d3c; }
+.heatmap-scale-3 { background-color: #e31a1c; }


### PR DESCRIPTION
## Summary
- add custom heatmap color classes with a ColorBrewer sequential palette
- update DailyHeatmap, CalendarHeatmap and RunHeatmap to use new colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68883a76f8788324bac2efed404e2042