### PR TITLE
Improve KPI card layout

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -42,10 +42,10 @@ export default function KPIGrid() {
   }, []);
 
   return (
-    <div className="grid gap-4 sm:grid-cols-3">
+    <div className="grid gap-4 sm:grid-cols-3 auto-rows-fr">
       {loading &&
         Array.from({ length: 3 }).map((_, i) => (
-          <Card key={i} className="animate-pulse">
+          <Card key={i} className="animate-pulse flex flex-col h-full">
             <CardHeader>
               <CardTitle>
                 <Skeleton className="h-6 w-24" />
@@ -61,7 +61,7 @@ export default function KPIGrid() {
       )}
       {!loading && !error &&
         items.map((item) => (
-          <Card key={item.label}>
+          <Card key={item.label} className="flex flex-col h-full">
             <CardHeader>
               <CardTitle>{item.label}</CardTitle>
             </CardHeader>

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -43,7 +43,7 @@ export default function ProgressRing({
         </RadialBarChart>
       </ResponsiveContainer>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-xl font-bold leading-none">{value}</span>
+        <span className="text-3xl font-extrabold leading-none">{value}</span>
         {unit && (
           <span className="text-xs text-muted-foreground">{unit}</span>
         )}


### PR DESCRIPTION
## Summary
- keep Steps/Sleep/HR Avg cards the same size
- increase KPI value font size inside progress ring

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68883ab192e48324af27d1d2fbd462ad