### PR TITLE
Add dashboard page with shadcn cards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,60 +1,13 @@
 import React from "react";
 import Header from "./components/Header";
-import KPIGrid from "./components/KPIGrid";
-import TrendsSection from "./components/TrendsSection";
-import DailyHeatmap from "./components/DailyHeatmap";
-import RunHeatmap from "./components/RunHeatmap";
-import CumulativeChart from "./components/CumulativeChart";
-import SummaryCard from "./components/SummaryCard";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/Tabs";
-const MapSection = React.lazy(() => import("./components/MapSection"));
-const AnalysisSection = React.lazy(() => import("./components/AnalysisSection"));
+import DashboardPage from "./components/DashboardPage";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Header />
-      <main className="container mx-auto space-y-6 py-6">
-        <SummaryCard />
-        <Tabs defaultValue="dashboard" className="space-y-6">
-          <TabsList className="mb-4">
-            <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
-            <TabsTrigger value="map">Map</TabsTrigger>
-            <TabsTrigger value="analysis">Analysis</TabsTrigger>
-            <TabsTrigger value="mileage">Mileage</TabsTrigger>
-          </TabsList>
-          <TabsContent value="dashboard" className="space-y-6">
-            <KPIGrid />
-            <TrendsSection />
-            <DailyHeatmap />
-            <RunHeatmap />
-          </TabsContent>
-          <TabsContent value="map" className="space-y-6">
-            <React.Suspense
-              fallback={
-                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
-                  Loading map...
-                </div>
-              }
-            >
-              <MapSection />
-            </React.Suspense>
-          </TabsContent>
-          <TabsContent value="analysis" className="space-y-6">
-            <React.Suspense
-              fallback={
-                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
-                  Loading analysis...
-                </div>
-              }
-            >
-              <AnalysisSection />
-            </React.Suspense>
-          </TabsContent>
-          <TabsContent value="mileage" className="space-y-6">
-            <CumulativeChart />
-          </TabsContent>
-        </Tabs>
+      <main className="container mx-auto">
+        <DashboardPage />
       </main>
     </div>
   );

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import WeeklySummaryCard from "./WeeklySummaryCard";
+import SummaryCard from "./SummaryCard";
+import KPIGrid from "./KPIGrid";
+import TrendsSection from "./TrendsSection";
+import DailyHeatmap from "./DailyHeatmap";
+import RunHeatmap from "./RunHeatmap";
+import CumulativeChart from "./CumulativeChart";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
+const MapSection = React.lazy(() => import("./MapSection"));
+const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <WeeklySummaryCard />
+      <SummaryCard>
+        <Tabs defaultValue="dashboard" className="space-y-6">
+          <TabsList className="grid w-full grid-cols-4 mb-4">
+            <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+            <TabsTrigger value="map">Map</TabsTrigger>
+            <TabsTrigger value="analysis">Analysis</TabsTrigger>
+            <TabsTrigger value="mileage">Mileage</TabsTrigger>
+          </TabsList>
+          <TabsContent value="dashboard" className="space-y-6">
+            <KPIGrid />
+            <TrendsSection />
+            <DailyHeatmap />
+            <RunHeatmap />
+          </TabsContent>
+          <TabsContent value="map" className="space-y-6">
+            <React.Suspense
+              fallback={
+                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
+                  Loading map...
+                </div>
+              }
+            >
+              <MapSection />
+            </React.Suspense>
+          </TabsContent>
+          <TabsContent value="analysis" className="space-y-6">
+            <React.Suspense
+              fallback={
+                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
+                  Loading analysis...
+                </div>
+              }
+            >
+              <AnalysisSection />
+            </React.Suspense>
+          </TabsContent>
+          <TabsContent value="mileage" className="space-y-6">
+            <CumulativeChart />
+          </TabsContent>
+        </Tabs>
+      </SummaryCard>
+    </div>
+  );
+}

--- a/frontend/src/components/RunHeatmap.jsx
+++ b/frontend/src/components/RunHeatmap.jsx
@@ -59,7 +59,13 @@ export default function RunHeatmap() {
     count: r.distance / 1609.34,
   }));
 
-  const palette = ["heatmap-scale-0", "heatmap-scale-1", "heatmap-scale-2", "heatmap-scale-3"];
+  const palette = [
+    "heatmap-scale-0",
+    "heatmap-scale-1",
+    "heatmap-scale-2",
+    "heatmap-scale-3",
+  ];
+
   return (
     <div ref={heatmapRef}>
       <CalendarHeatmap
@@ -70,36 +76,21 @@ export default function RunHeatmap() {
         titleForValue={(v) =>
           v && v.date ? `${v.date}: ${(v.count ?? 0).toFixed(1)} mi` : null
         }
-
         classForValue={(v) => {
           if (!v || v.count === null || v.count === undefined) {
             return "heatmap-empty";
           }
-          return v.count > 10
-            ? "heatmap-4"
-            : v.count > 5
-            ? "heatmap-3"
-            : v.count > 2
-            ? "heatmap-2"
-            : "heatmap-1";
+          const c = v.count;
+          let idx = 0;
+          if (c > 10) idx = 3;
+          else if (c > 5) idx = 2;
+          else if (c > 2) idx = 1;
+          return palette[idx];
         }}
         tooltipDataAttrs={(v) => ({
           "data-tip": `${v.date}: ${(v.count ?? 0).toFixed(1)}\u00a0mi`,
         })}
       />
     </div>
-
-        const c = v.count;
-        let idx = 0;
-        if (c > 10) idx = 3;
-        else if (c > 5) idx = 2;
-        else if (c > 2) idx = 1;
-        return palette[idx];
-      }}
-      tooltipDataAttrs={(v) => ({
-        "data-tip": `${v.date}: ${(v.count ?? 0).toFixed(1)}\u00a0mi`,
-      })}
-    />
-
   );
 }

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardHeader, CardTitle } from "./ui/Card";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
 import Skeleton from "./ui/Skeleton";
 import { fetchRuns } from "../api";
 import { parseISO, differenceInCalendarDays } from "date-fns";
@@ -32,7 +32,7 @@ export function computeSummary(runs = []) {
   return { runCount: runs.length, streak, ...totals };
 }
 
-export default function SummaryCard() {
+export default function SummaryCard({ children }) {
   const [summary, setSummary] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
@@ -62,6 +62,7 @@ export default function SummaryCard() {
           </>
         )}
       </CardHeader>
+      {children && <CardContent>{children}</CardContent>}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- implement `DashboardPage` component combining run summary with tabbed sections
- extend `SummaryCard` to support children content
- simplify `App` to render the new dashboard page
- fix syntax issue in `RunHeatmap` for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888414c30e88324ae104aa991ae23af