### PR TITLE
Limit weekly summary to last 7 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,6 @@ from dummy tracks otherwise.
 The Summary Card shown at the top of the app is implemented in
 `frontend/src/components/WeeklySummaryCard.jsx`. It fetches step counts, sleep
 hours and daily totals using the API helpers and displays the aggregated values
-with two sparklines.
+with two sparklines. Weekly totals only take the most recent seven days into
+account.
 

--- a/frontend/src/components/RunHeatmap.jsx
+++ b/frontend/src/components/RunHeatmap.jsx
@@ -89,17 +89,5 @@ export default function RunHeatmap() {
       />
     </div>
 
-        const c = v.count;
-        let idx = 0;
-        if (c > 10) idx = 3;
-        else if (c > 5) idx = 2;
-        else if (c > 2) idx = 1;
-        return palette[idx];
-      }}
-      tooltipDataAttrs={(v) => ({
-        "data-tip": `${v.date}: ${(v.count ?? 0).toFixed(1)}\u00a0mi`,
-      })}
-    />
-
   );
 }

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -26,9 +26,15 @@ export default function WeeklySummaryCard({ children }) {
       .finally(() => setLoading(false));
   }, []);
 
-  const totalSteps = steps.reduce((sum, p) => sum + p.value, 0);
-  const totalSleep = sleep.reduce((sum, p) => sum + p.value, 0);
-  const totalDistanceKm = totals.reduce((sum, p) => sum + p.distance, 0) / 1000;
+  // Only consider the last 7 days for the weekly summary
+  const stepsLast7 = steps.slice(-7);
+  const sleepLast7 = sleep.slice(-7);
+  const totalsLast7 = totals.slice(-7);
+
+  const totalSteps = stepsLast7.reduce((sum, p) => sum + p.value, 0);
+  const totalSleep = sleepLast7.reduce((sum, p) => sum + p.value, 0);
+  const totalDistanceKm =
+    totalsLast7.reduce((sum, p) => sum + p.distance, 0) / 1000;
 
   return (
     <Card className="mb-4 animate-in fade-in">
@@ -59,7 +65,7 @@ export default function WeeklySummaryCard({ children }) {
             <>
               <div className="h-8 w-20">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={steps} margin={{ top: 2, bottom: 2 }}>
+                  <LineChart data={stepsLast7} margin={{ top: 2, bottom: 2 }}>
                     <Line
                       type="monotone"
                       dataKey="value"
@@ -72,7 +78,7 @@ export default function WeeklySummaryCard({ children }) {
               </div>
               <div className="h-8 w-20">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={sleep} margin={{ top: 2, bottom: 2 }}>
+                  <LineChart data={sleepLast7} margin={{ top: 2, bottom: 2 }}>
                     <Line
                       type="monotone"
                       dataKey="value"


### PR DESCRIPTION
## Summary
- slice step, sleep, and totals data to the most recent 7 entries in `WeeklySummaryCard`
- adjust sparklines to use the sliced data
- note that weekly totals only reflect the past 7 days in README
- clean up stray code in `RunHeatmap` preventing tests from running

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688841a35a2883248548abedf43dbe89