### PR TITLE
Auto-select latest activity in map section

### DIFF
--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -3,7 +3,11 @@ import ChartCard from "./ChartCard";
 import ActivityCalendar from "./ActivityCalendar";
 import CalendarHeatmap from "./CalendarHeatmap";
 import { Card, CardContent } from "./ui/Card";
-import { fetchActivityTrack, fetchRoutes } from "../api";
+import {
+  fetchActivityTrack,
+  fetchActivitiesByDate,
+  fetchRoutes,
+} from "../api";
 import ElevationChart from "./ElevationChart";
 const LazyMap = React.lazy(() => import("./LeafletMap"));
 const LazyHeatmap = React.lazy(() => import("./RouteHeatmap"));
@@ -33,6 +37,20 @@ export default function MapSection() {
       .catch(() => setError("Failed to load map"))
       .finally(() => setLoading(false));
   }, []);
+
+  React.useEffect(() => {
+    fetchActivitiesByDate()
+      .then((data) => {
+        const dates = Object.keys(data).sort();
+        const latest = dates[dates.length - 1];
+        if (latest && data[latest]?.length) {
+          loadTrack(data[latest][0]);
+        }
+      })
+      .catch(() => {
+        /* ignore initial load errors */
+      });
+  }, [loadTrack]);
 
   React.useEffect(() => {
     setLoadingRoutes(true);

--- a/frontend/src/components/__tests__/MapSection.test.jsx
+++ b/frontend/src/components/__tests__/MapSection.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import MapSection from '../MapSection';
+
+vi.mock('../ActivityCalendar', () => ({ default: () => <div data-testid="calendar" /> }));
+vi.mock('../CalendarHeatmap', () => ({ default: () => <div data-testid="heatmap" /> }));
+vi.mock('../LeafletMap', () => ({ default: () => <div data-testid="leaflet" /> }));
+vi.mock('../RouteHeatmap', () => ({ default: () => <div data-testid="routeheat" /> }));
+vi.mock('../ElevationChart', () => ({ default: () => <div data-testid="elev" /> }));
+
+it('loads the most recent activity on mount', async () => {
+  global.fetch = vi.fn((url) => {
+    if (url === '/activities/by-date') {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            '2023-01-01': [{ activityId: 'a1', lat: 0, lon: 0 }],
+            '2023-01-02': [{ activityId: 'a2', lat: 0, lon: 0 }],
+          }),
+      });
+    }
+    if (url === '/activities/a2/track') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{ lat: 0, lon: 0 }]),
+      });
+    }
+    if (url.startsWith('/routes')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+  });
+
+  render(<MapSection />);
+  await waitFor(() => expect(screen.getByTestId('leaflet')).toBeInTheDocument());
+  expect(global.fetch).toHaveBeenCalledWith('/activities/by-date');
+  expect(global.fetch).toHaveBeenCalledWith('/activities/a2/track');
+});


### PR DESCRIPTION
## Summary
- load the most recent activity when the map section mounts
- test that MapSection auto-loads the latest activity

## Testing
- `npm test` in `frontend`
- `python -m pytest -q` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6888455c49d08324844fa2d473678416