### PR TITLE
Apply teal color theme

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -46,7 +46,7 @@ export default function KPIGrid() {
       {loading &&
         Array.from({ length: 3 }).map((_, i) => (
 
-          <Card key={i} className="animate-in fade-in animate-pulse">
+          <Card key={i} className="animate-in fade-in animate-pulse bg-neutral-100 text-primary">
 
             <CardHeader>
               <CardTitle>
@@ -64,7 +64,7 @@ export default function KPIGrid() {
       {!loading && !error &&
         items.map((item) => (
 
-          <Card key={item.label} className="animate-in fade-in">
+          <Card key={item.label} className="animate-in fade-in bg-neutral-100 text-primary">
 
             <CardHeader>
               <CardTitle>{item.label}</CardTitle>

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -46,7 +46,7 @@ export default function SummaryCard({ children }) {
 
   return (
     <Card className="animate-in fade-in">
-      <CardHeader>
+      <CardHeader className="border-b border-border text-primary">
         {loading && <Skeleton className="h-6 w-32" />}
         {error && !loading && (
           <div className="text-sm text-destructive">{error}</div>

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -37,7 +37,7 @@ export default function WeeklySummaryCard({ children }) {
     totalsLast7.reduce((sum, p) => sum + p.distance, 0) / 1000;
 
   return (
-    <Card className="mb-4 animate-in fade-in">
+    <Card className="mb-4 animate-in fade-in bg-secondary text-secondary-foreground">
       <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1">
           {loading && <Skeleton className="h-6 w-32" />}
@@ -69,7 +69,7 @@ export default function WeeklySummaryCard({ children }) {
                     <Line
                       type="monotone"
                       dataKey="value"
-                      stroke="hsl(var(--primary))"
+                      stroke="hsl(var(--accent))"
                       fill="none"
                       dot={false}
                     />
@@ -82,7 +82,7 @@ export default function WeeklySummaryCard({ children }) {
                     <Line
                       type="monotone"
                       dataKey="value"
-                      stroke="hsl(var(--primary))"
+                      stroke="hsl(var(--accent))"
                       fill="none"
                       dot={false}
                     />

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -2,19 +2,24 @@
 
 /* 1) Light‑mode defaults */
 :root {
-  /* neutral black & white palette */
-  --background:         #ffffff;
-  --foreground:         #000000;
-  --accent:             #000000;
-  --accent-foreground:  #ffffff;
+  /* core palette */
+  --background:          0 0% 97%;      /* Neutral 200 */
+  --foreground:          194 88% 13%;   /* On Secondary */
+  --card:                46 59% 87%;    /* Secondary */
+  --card-foreground:     194 88% 13%;   /* On Secondary */
+  --accent:              45 46% 56%;    /* Accent */
+  --accent-foreground:   194 88% 13%;   /* On Accent */
 
-  /* set plugin variables to greyscale */
-  --primary:            0 0% 0%;
-  --primary-foreground: 0 0% 100%;
-  --secondary:          0 0% 100%;
-  --secondary-foreground: 0 0% 0%;
-  --destructive:        0 0% 0%;
+  /* shadcn/ui variables */
+  --primary:             194 88% 13%;
+  --primary-foreground:  46 59% 87%;
+  --secondary:           46 59% 87%;
+  --secondary-foreground: 194 88% 13%;
+  --destructive:         0 85% 60%;
   --destructive-foreground: 0 0% 100%;
+  --border:              48 25% 76%;
+  --input:               48 25% 76%;
+  --ring:                45 46% 56%;
 }
 
 /* 2) Tailwind layers */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -19,13 +19,13 @@ module.exports = {
       // 3. Map semantic Tailwind colors to your CSS variables
       colors: {
         // page-level
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        background: "hsl(var(--background) / <alpha-value>)",
+        foreground: "hsl(var(--foreground) / <alpha-value>)",
 
         // primary accent
         accent: {
-          DEFAULT: "var(--accent)",
-          foreground: "var(--accent-foreground)",
+          DEFAULT: "hsl(var(--accent) / <alpha-value>)",
+          foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
         },
 
         // optional “tone” palette if you still need it


### PR DESCRIPTION
## Summary
- customize Tailwind CSS variables with a teal palette
- map Tailwind semantic colors to `hsl()` values
- style WeeklySummaryCard, SummaryCard, and KPIGrid with new colors

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888451b88a08324ba75700edd0d8fc5