### PR TITLE
Fix KPIGrid card height

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -46,7 +46,7 @@ export default function KPIGrid() {
       {loading &&
         Array.from({ length: 3 }).map((_, i) => (
 
-          <Card key={i} className="animate-in fade-in animate-pulse">
+          <Card key={i} className="animate-in fade-in animate-pulse h-40">
 
             <CardHeader>
               <CardTitle>
@@ -64,7 +64,7 @@ export default function KPIGrid() {
       {!loading && !error &&
         items.map((item) => (
 
-          <Card key={item.label} className="animate-in fade-in">
+          <Card key={item.label} className="animate-in fade-in h-40">
 
             <CardHeader>
               <CardTitle>{item.label}</CardTitle>


### PR DESCRIPTION
## Summary
- update KPIGrid cards to use a fixed height so all KPI cards stay uniform

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688847b76ebc8324bd8638d6cf49b505