### PR TITLE
Add logo and brand color

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#2563eb"/>
+  <path d="M50 20 L70 80 L50 60 L30 80 Z" fill="white"/>
+</svg>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -2,5 +2,10 @@ import React from "react";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 
 export default function Header() {
-  return <WeeklySummaryCard />;
+  return (
+    <header className="container mx-auto flex items-center gap-4 py-4">
+      <img src="/logo.svg" alt="Logo" className="h-10 w-auto" />
+      <WeeklySummaryCard />
+    </header>
+  );
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -5,7 +5,7 @@
   /* neutral black & white palette */
   --background:         #ffffff;
   --foreground:         #000000;
-  --accent:             #000000;
+  --accent:             #2563eb;
   --accent-foreground:  #ffffff;
 
   /* set plugin variables to greyscale */


### PR DESCRIPTION
## Summary
- add a simple SVG logo under `public`
- display the logo in the Header component
- set `--accent` variable to a blue brand color

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6888486d5f7483248f404d8c8ca6df0c