### PR TITLE
Refine typography across dashboard

### DIFF
--- a/frontend/src/components/ActivityCalendar.jsx
+++ b/frontend/src/components/ActivityCalendar.jsx
@@ -18,7 +18,7 @@ export default function ActivityCalendar({ onSelect }) {
     return <Skeleton className="h-40 w-full" />;
   }
   if (error) {
-    return <div className="text-sm text-destructive">{error}</div>;
+    return <div className="text-sm font-normal text-destructive">{error}</div>;
   }
 
   const activityDates = Object.keys(days).sort();
@@ -44,7 +44,7 @@ export default function ActivityCalendar({ onSelect }) {
   }
 
   return (
-    <div className="grid grid-cols-7 gap-1 text-sm">
+    <div className="grid grid-cols-7 gap-1 text-sm font-normal">
       {cells.map((date, idx) => {
         if (!date) return <div key={"empty-" + idx}></div>;
         const acts = days[date];

--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -9,7 +9,7 @@ function AnalysisTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { temperature, avgPace } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm shadow">
+    <div className="rounded bg-background p-2 text-sm font-normal shadow">
       <div className="flex items-center gap-1">
         <span>🌡️</span>
         <span>{temperature}°C</span>
@@ -40,7 +40,7 @@ export default function AnalysisSection() {
         <div className="h-64">
           {loading && <Skeleton className="h-full w-full" />}
           {error && (
-            <div className="flex h-full items-center justify-center text-sm text-destructive">{error}</div>
+            <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">{error}</div>
           )}
           {!loading && !error && (
             <ResponsiveContainer width="100%" height="100%">

--- a/frontend/src/components/CalendarHeatmap.jsx
+++ b/frontend/src/components/CalendarHeatmap.jsx
@@ -18,10 +18,10 @@ export default function CalendarHeatmap() {
     return <Skeleton className="h-20 w-full" />;
   }
   if (error) {
-    return <div className="text-sm text-destructive">{error}</div>;
+    return <div className="text-sm font-normal text-destructive">{error}</div>;
   }
   if (!data.length) {
-    return <div className="text-sm text-muted-foreground">No data</div>;
+    return <div className="text-sm font-normal text-muted-foreground">No data</div>;
   }
 
   const max = Math.max(...data.map((d) => d.distance));

--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -66,12 +66,12 @@ export default function CumulativeChart() {
       <div className="h-64">
         {loading && <Skeleton className="h-full w-full" />}
         {error && (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
+          <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
             {error}
           </div>
         )}
         {!loading && !error && data.length === 0 && (
-          <div className="text-sm text-muted-foreground">No data</div>
+          <div className="text-sm font-normal text-muted-foreground">No data</div>
         )}
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">

--- a/frontend/src/components/DailyHeatmap.jsx
+++ b/frontend/src/components/DailyHeatmap.jsx
@@ -18,10 +18,10 @@ export default function DailyHeatmap() {
     return <Skeleton className="h-20 w-full" />;
   }
   if (error) {
-    return <div className="text-sm text-destructive">{error}</div>;
+    return <div className="text-sm font-normal text-destructive">{error}</div>;
   }
   if (!data.length) {
-    return <div className="text-sm text-muted-foreground">No data</div>;
+    return <div className="text-sm font-normal text-muted-foreground">No data</div>;
   }
   const max = Math.max(...data.map((d) => d.distance));
   return (

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -31,7 +31,7 @@ export default function DashboardPage() {
           <TabsContent value="map" className="space-y-6">
             <React.Suspense
               fallback={
-                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
+                <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
                   Loading map...
                 </div>
               }
@@ -42,7 +42,7 @@ export default function DashboardPage() {
           <TabsContent value="analysis" className="space-y-6">
             <React.Suspense
               fallback={
-                <div className="h-64 flex items-center justify-center text-sm text-muted-foreground">
+                <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
                   Loading analysis...
                 </div>
               }

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -15,7 +15,7 @@ function ElevationTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { dist, elevation } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm shadow">
+    <div className="rounded bg-background p-2 text-sm font-normal shadow">
       <div className="flex items-center gap-1">
         <span>⛰️</span>
         <span>{elevation.toFixed(0)} m</span>

--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -16,7 +16,7 @@ function ZoneTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { zone, value } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm shadow">
+    <div className="rounded bg-background p-2 text-sm font-normal shadow">
       <div>{zone}</div>
       <div className="flex items-center gap-1">
         <span>❤️</span>
@@ -63,7 +63,7 @@ export default function HRZonesBar() {
       <div className="h-40">
         {loading && <Skeleton className="h-full w-full" />}
         {error && (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
+          <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
             {error}
           </div>
         )}

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -59,7 +59,7 @@ export default function KPIGrid() {
           </Card>
         ))}
       {error && (
-        <div className="col-span-3 text-center text-sm text-destructive">{error}</div>
+        <div className="col-span-3 text-center text-sm font-normal text-destructive">{error}</div>
       )}
       {!loading && !error &&
         items.map((item) => (

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -87,19 +87,19 @@ export default function MapSection() {
           <Card className="flex-1">
             <CardContent className="h-64 p-0">
               {loading && (
-                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                   Loading...
                 </div>
               )}
               {error && (
-                <div className="flex h-full items-center justify-center text-sm text-destructive">
+                <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
                   {error}
                 </div>
               )}
               {!loading && !error && points.length > 0 && (
                 <React.Suspense
                   fallback={
-                    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                       Loading map...
                     </div>
                   }
@@ -149,19 +149,19 @@ export default function MapSection() {
         <Card>
           <CardContent className="h-64 p-0">
             {loadingRoutes && (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                 Loading...
               </div>
             )}
             {errorRoutes && (
-              <div className="flex h-full items-center justify-center text-sm text-destructive">
+              <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
                 {errorRoutes}
               </div>
             )}
             {!loadingRoutes && !errorRoutes && routes.length > 0 && (
               <React.Suspense
                 fallback={
-                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                     Loading map...
                   </div>
                 }

--- a/frontend/src/components/RunHeatmap.jsx
+++ b/frontend/src/components/RunHeatmap.jsx
@@ -50,9 +50,10 @@ export default function RunHeatmap() {
   }, [runs]);
 
   if (loading) return <Skeleton className="h-20 w-full" />;
-  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (error)
+    return <div className="text-sm font-normal text-destructive">{error}</div>;
   if (!runs.length)
-    return <div className="text-sm text-muted-foreground">No data</div>;
+    return <div className="text-sm font-normal text-muted-foreground">No data</div>;
 
   const values = runs.map((r) => ({
     date: r.date,

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -19,7 +19,7 @@ function StepTooltip({ active, payload, label }) {
   const value = payload[0].value;
   const date = label.split("T")[0];
   return (
-    <div className="rounded bg-background p-2 text-sm shadow">
+    <div className="rounded bg-background p-2 text-sm font-normal shadow">
       <div>{date}</div>
       <div className="flex items-center gap-1">
         <span>🚶</span>
@@ -50,7 +50,7 @@ export default function StepsSparkline() {
       <div className="h-40">
         {loading && <Skeleton className="h-full w-full" />}
         {error && (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
+          <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">
             {error}
           </div>
         )}

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -49,12 +49,12 @@ export default function SummaryCard({ children }) {
       <CardHeader>
         {loading && <Skeleton className="h-6 w-32" />}
         {error && !loading && (
-          <div className="text-sm text-destructive">{error}</div>
+          <div className="text-sm font-normal text-destructive">{error}</div>
         )}
         {!loading && !error && summary && (
           <>
             <CardTitle>Run Summary</CardTitle>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-sm font-normal text-muted-foreground">
               {summary.runCount} runs &bull;{" "}
               {(summary.totalDistance / 1000).toFixed(1)} km &bull;{" "}
               {summary.streak} day streak

--- a/frontend/src/components/TimeOfDay.jsx
+++ b/frontend/src/components/TimeOfDay.jsx
@@ -64,7 +64,7 @@ export default function TimeOfDay() {
       <div className="h-64">
         {loading && <Skeleton className="h-full w-full" />}
         {error && (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">{error}</div>
+          <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">{error}</div>
         )}
         {!loading && !error && <Scatter data={data} options={options} />}
       </div>

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -42,12 +42,12 @@ export default function WeeklySummaryCard({ children }) {
         <div className="flex flex-col gap-1">
           {loading && <Skeleton className="h-6 w-32" />}
           {error && !loading && (
-            <div className="text-sm text-destructive">{error}</div>
+            <div className="text-sm font-normal text-destructive">{error}</div>
           )}
           {!loading && !error && (
             <>
-              <div className="text-xl font-semibold">Weekly Totals</div>
-              <div className="text-sm text-muted-foreground">
+              <div className="text-2xl font-semibold">Weekly Totals</div>
+              <div className="text-sm font-normal text-muted-foreground">
                 {totalDistanceKm.toFixed(1)} km &bull; {totalSteps} steps &bull;{' '}
                 {totalSleep.toFixed(1)}h sleep
               </div>

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -18,7 +18,11 @@ export function CardHeader({ className = "", children }) {
 }
 
 export function CardTitle({ className = "", children }) {
-  return <h3 className={"text-2xl font-semibold leading-none tracking-tight " + className}>{children}</h3>;
+  return (
+    <h3 className={"text-xl font-semibold leading-snug " + className}>
+      {children}
+    </h3>
+  );
 }
 
 export function CardContent({ className = "", children }) {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -22,6 +22,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply leading-snug;
+  }
+}
+
 /* ColorBrewer YlOrRd palette for heatmap intensity */
 .heatmap-scale-0 { background-color: #ffffb2; }
 .heatmap-scale-1 { background-color: #fecc5c; }


### PR DESCRIPTION
## Summary
- update `CardTitle` typography
- tweak WeeklySummaryCard header styling
- set consistent body text styles
- add base line-height in global CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688848a510a48324ae6d997dfc40bd87