### PR TITLE
Revise chart colors and styling

### DIFF
--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -76,7 +76,7 @@ export default function CumulativeChart() {
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" />
+              <CartesianGrid stroke="hsl(var(--muted))" strokeDasharray="3 3" horizontal={false} />
               <XAxis dataKey="month" />
               <YAxis unit="km" />
               <Tooltip formatter={(v) => `${v.toFixed(1)} km`} />

--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -36,10 +36,10 @@ export default function HRZonesBar() {
     fetchHeartrate()
       .then((data) => {
         const zoneDefs = [
-          { label: "Easy", min: 0, max: 99, color: "#10b981" },
-          { label: "Fat Burn", min: 100, max: 119, color: "#facc15" },
-          { label: "Cardio", min: 120, max: 139, color: "#f97316" },
-          { label: "Peak", min: 140, max: Infinity, color: "#ef4444" },
+          { label: "Easy", min: 0, max: 99, shade: 0.25 },
+          { label: "Fat Burn", min: 100, max: 119, shade: 0.5 },
+          { label: "Cardio", min: 120, max: 139, shade: 0.75 },
+          { label: "Peak", min: 140, max: Infinity, shade: 1 },
         ];
         const counts = zoneDefs.map(() => 0);
         for (const p of data) {
@@ -51,7 +51,11 @@ export default function HRZonesBar() {
           }
         }
         setZones(
-          zoneDefs.map((z, i) => ({ zone: z.label, value: counts[i], color: z.color }))
+          zoneDefs.map((z, i) => ({
+            zone: z.label,
+            value: counts[i],
+            color: `hsl(var(--accent) / ${z.shade})`,
+          }))
         );
       })
       .catch(() => setError("Failed to load"))

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -33,10 +33,8 @@ export default function StepsSparkline() {
   const [steps, setSteps] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
-  const gradientId = React.useId();
-  const styles = getComputedStyle(document.documentElement);
-  const accent = styles.getPropertyValue('--color-accent').trim();
-  const primary = styles.getPropertyValue('--primary').trim();
+  const primary = 'hsl(var(--primary))';
+  const accent = 'var(--accent)';
 
   React.useEffect(() => {
     fetchSteps()
@@ -57,18 +55,12 @@ export default function StepsSparkline() {
         {!loading && !error && (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-              <defs>
-                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor={accent} stopOpacity={0.8} />
-                  <stop offset="100%" stopColor={primary} stopOpacity={0.2} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" />
+              <CartesianGrid stroke="hsl(var(--muted))" strokeDasharray="3 3" />
               <XAxis dataKey="timestamp" tick={false} />
               <YAxis />
               <Tooltip content={<StepTooltip />} />
               <ReferenceLine y={10000} stroke={primary} strokeDasharray="3 3" label={{ position: 'right', value: 'Goal' }} />
-              <Area type="monotone" dataKey="value" stroke={primary} fill={`url(#${gradientId})`} dot={false} />
+              <Area type="monotone" dataKey="value" stroke={primary} fill={accent} fillOpacity={0.3} dot={false} />
               <Brush dataKey="timestamp" height={20} travellerWidth={10} />
             </AreaChart>
           </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- tweak StepsSparkline with accent fill and muted grid
- tone down grid lines in CumulativeChart
- shade HR zones using accent color

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688849fa3bc083248a6c6104cb7d7770