### PR TITLE
Update layout widths and spacing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Header />
-      <main className="container mx-auto">
+      <main className="mx-auto max-w-[1200px]">
         <DashboardPage />
       </main>
     </div>

--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -35,7 +35,7 @@ export default function AnalysisSection() {
   }, []);
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid gap-10 sm:grid-cols-2">
       <ChartCard title="Pace vs Temperature">
         <div className="h-64">
           {loading && <Skeleton className="h-full w-full" />}

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -62,7 +62,7 @@ export default function KPIGrid() {
   }, []);
 
   return (
-    <div className="grid gap-4 sm:grid-cols-3 auto-rows-fr">
+    <div className="grid gap-10 sm:grid-cols-3 auto-rows-fr">
       {loading &&
         Array.from({ length: 3 }).map((_, i) => (
 

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -85,7 +85,7 @@ export default function MapSection() {
           </label>
         </div>
           <Card className="flex-1">
-            <CardContent className="h-64 p-0">
+            <CardContent className="h-64 p-6">
               {loading && (
                 <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                   Loading...
@@ -147,7 +147,7 @@ export default function MapSection() {
           />
         </div>
         <Card>
-          <CardContent className="h-64 p-0">
+          <CardContent className="h-64 p-6">
             {loadingRoutes && (
               <div className="flex h-full items-center justify-center text-sm font-normal text-muted-foreground">
                 Loading...

--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -4,7 +4,7 @@ import HRZonesBar from "./HRZonesBar";
 
 export default function TrendsSection() {
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid gap-10 sm:grid-cols-2">
       <StepsSparkline />
       <HRZonesBar />
     </div>


### PR DESCRIPTION
## Summary
- keep the main app container centered with a `max-w-[1200px]`
- widen gaps in dashboard grids for more breathing room
- use consistent padding inside MapSection cards

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68884cc3dccc8324980359ae97338d03