### PR TITLE
Switch to Lucide icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The "Mileage" tab visualizes your cumulative distance per month in a line chart.
 
 ## Tailwind Theme Setup
 
-The `src/main.jsx` entry point imports `@/index.css` which includes `tailwindcss-shadcn-ui/style.css` so shadcn/ui component styles are loaded.
+The `src/main.jsx` entry point imports `@/index.css` which includes `tailwindcss-shadcn-ui/style.css` so shadcn/ui component styles are loaded. The interface uses icons from the **Lucide** set via the `lucide-react` package.
 
 The preset is enabled in `tailwind.config.js` via `createPreset` to load the component styles and map colors to CSS variables:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,11 +12,11 @@
         "chart.js": "^4.4.0",
         "date-fns": "^3.6.0",
         "leaflet": "^1.9.4",
+        "lucide-react": "^0.532.0",
         "react": "^18.2.0",
         "react-calendar-heatmap": "1.9.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.12.0",
         "react-leaflet": "^4.2.1",
         "recharts": "^3.1.0"
       },
@@ -3334,6 +3334,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.532.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.532.0.tgz",
+      "integrity": "sha512-HwmXOIZwuZ21wryFq0ZrwkjAMxI77+jLxLdNzWCiUa/Kf5ozkTFCWT6C1/yapP68uKgj8wlxxqnNCH1xo9NEpg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4056,15 +4065,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,11 @@
     "chart.js": "^4.4.0",
     "date-fns": "^3.6.0",
     "leaflet": "^1.9.4",
+    "lucide-react": "^0.532.0",
     "react": "^18.2.0",
     "react-calendar-heatmap": "1.9.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.12.0",
     "react-leaflet": "^4.2.1",
     "recharts": "^3.1.0"
   },

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -3,8 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/Card";
 import ProgressRing from "./ui/ProgressRing";
 import { fetchHeartrate, fetchSleep, fetchSteps } from "../api";
 import Skeleton from "./ui/Skeleton";
-import { GiFootsteps } from "react-icons/gi";
-import { FaBed, FaHeart } from "react-icons/fa";
+import { Footprints, BedDouble, Heart } from "lucide-react";
 
 export default function KPIGrid() {
   const [items, setItems] = React.useState([]);
@@ -33,21 +32,21 @@ export default function KPIGrid() {
             value: latestSteps,
             goal: 10000,
             unit: "",
-            icon: GiFootsteps,
+            icon: Footprints,
           },
           {
             label: "Sleep",
             value: lastSleep,
             goal: 8,
             unit: "h",
-            icon: FaBed,
+            icon: BedDouble,
           },
           {
             label: "HR Avg",
             value: avgHr,
             goal: 100,
             unit: "bpm",
-            icon: FaHeart,
+            icon: Heart,
           },
         ]);
       } catch (err) {


### PR DESCRIPTION
## Summary
- use `lucide-react` for the app icon set
- replace KPI icons with Lucide icons
- document use of Lucide icons in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68884b830ed08324a43437c573fb936d