### PR TITLE
Improve tab and tooltip styles

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -9,7 +9,7 @@ function AnalysisTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { temperature, avgPace } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm font-normal shadow">
+    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
       <div className="flex items-center gap-1">
         <span>🌡️</span>
         <span>{temperature}°C</span>

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -15,7 +15,7 @@ function ElevationTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { dist, elevation } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm font-normal shadow">
+    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
       <div className="flex items-center gap-1">
         <span>⛰️</span>
         <span>{elevation.toFixed(0)} m</span>

--- a/frontend/src/components/HRZonesBar.jsx
+++ b/frontend/src/components/HRZonesBar.jsx
@@ -16,7 +16,7 @@ function ZoneTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const { zone, value } = payload[0].payload;
   return (
-    <div className="rounded bg-background p-2 text-sm font-normal shadow">
+    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
       <div>{zone}</div>
       <div className="flex items-center gap-1">
         <span>❤️</span>

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -19,7 +19,7 @@ function StepTooltip({ active, payload, label }) {
   const value = payload[0].value;
   const date = label.split("T")[0];
   return (
-    <div className="rounded bg-background p-2 text-sm font-normal shadow">
+    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
       <div>{date}</div>
       <div className="flex items-center gap-1">
         <span>🚶</span>

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -4,7 +4,7 @@ export function Card({ className = "", children }) {
   return (
     <div
       className={
-        "rounded-xl border bg-card text-card-foreground shadow-sm transition-shadow transition-transform hover:-translate-y-0.5 hover:shadow-lg focus-within:shadow-md " +
+        "rounded-xl border bg-card text-card-foreground shadow-sm transition-shadow transition-transform hover:-translate-y-0.5 hover:shadow-lg focus-within:shadow-md hover:border-accent " +
         className
       }
     >

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -34,8 +34,16 @@ export function TabsTrigger({ value, className = "", children }) {
   return (
     <Button
       onClick={() => ctx.setValue(value)}
-      variant={active ? "default" : "ghost"}
-      className={"px-3 py-1.5 text-sm " + className}
+      variant="ghost"
+      className={
+        "px-3 py-1.5 text-sm border-b-2 transition-colors " +
+        (active
+          ? "border-accent text-accent-foreground"
+          : "border-transparent hover:border-accent hover:bg-accent/10") +
+        (active ? "" : "") +
+        " " +
+        className
+      }
     >
       {children}
     </Button>


### PR DESCRIPTION
## Summary
- show accent underline on active/hover tabs
- accentuate Card borders when hovering
- add borders to chart tooltips for better contrast

## Testing
- `cd frontend && npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68884e4a389c83248e64db0458ab7007