### PR TITLE
Add interactive controls to summary card

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ from dummy tracks otherwise.
 
 The Summary Card shown at the top of the app is implemented in
 `frontend/src/components/WeeklySummaryCard.jsx`. It fetches step counts, sleep
-hours and daily totals using the API helpers and displays the aggregated values
-with two sparklines. Weekly totals only take the most recent seven days into
-account.
+hours and daily totals using the API helpers. The header now offers a date range
+selector, quick filter buttons and export/share actions while the metrics and
+sparklines sit in the card content below.
 

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardHeader } from "./ui/Card";
+import { Card, CardHeader, CardContent } from "./ui/Card";
 import Skeleton from "./ui/Skeleton";
 import { fetchDailyTotals, fetchSteps, fetchSleep } from "../api";
 import {
@@ -7,6 +7,7 @@ import {
   Line,
   ResponsiveContainer,
 } from "recharts";
+import { Download, Share2 } from "lucide-react";
 
 export default function WeeklySummaryCard({ children }) {
   const [steps, setSteps] = React.useState([]);
@@ -14,6 +15,9 @@ export default function WeeklySummaryCard({ children }) {
   const [totals, setTotals] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
+  const [range, setRange] = React.useState("7");
+  const [startDate, setStartDate] = React.useState("");
+  const [endDate, setEndDate] = React.useState("");
 
   React.useEffect(() => {
     Promise.all([fetchSteps(), fetchSleep(), fetchDailyTotals()])
@@ -26,74 +30,136 @@ export default function WeeklySummaryCard({ children }) {
       .finally(() => setLoading(false));
   }, []);
 
-  // Only consider the last 7 days for the weekly summary
-  const stepsLast7 = steps.slice(-7);
-  const sleepLast7 = sleep.slice(-7);
-  const totalsLast7 = totals.slice(-7);
+  let filteredSteps = steps;
+  let filteredSleep = sleep;
+  let filteredTotals = totals;
 
-  const totalSteps = stepsLast7.reduce((sum, p) => sum + p.value, 0);
-  const totalSleep = sleepLast7.reduce((sum, p) => sum + p.value, 0);
+  if (range === "7" || range === "30") {
+    const days = parseInt(range, 10);
+    filteredSteps = steps.slice(-days);
+    filteredSleep = sleep.slice(-days);
+    filteredTotals = totals.slice(-days);
+  } else if (range === "month") {
+    const now = new Date();
+    const m = now.getMonth();
+    const y = now.getFullYear();
+    const inMonth = (d) => d.getMonth() === m && d.getFullYear() === y;
+    filteredSteps = steps.filter((p) => inMonth(new Date(p.timestamp)));
+    filteredSleep = sleep.filter((p) => inMonth(new Date(p.timestamp)));
+    filteredTotals = totals.filter((p) => inMonth(new Date(p.date)));
+  } else if (range === "custom" && startDate && endDate) {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    filteredSteps = steps.filter((p) => {
+      const d = new Date(p.timestamp);
+      return d >= start && d <= end;
+    });
+    filteredSleep = sleep.filter((p) => {
+      const d = new Date(p.timestamp);
+      return d >= start && d <= end;
+    });
+    filteredTotals = totals.filter((p) => {
+      const d = new Date(p.date);
+      return d >= start && d <= end;
+    });
+  }
+
+  const totalSteps = filteredSteps.reduce((sum, p) => sum + p.value, 0);
+  const totalSleep = filteredSleep.reduce((sum, p) => sum + p.value, 0);
   const totalDistanceKm =
-    totalsLast7.reduce((sum, p) => sum + p.distance, 0) / 1000;
+    filteredTotals.reduce((sum, p) => sum + p.distance, 0) / 1000;
+
+  function quick(days) {
+    setRange(days);
+    setStartDate("");
+    setEndDate("");
+  }
+
+  function handleExport() {
+    const rows = filteredTotals.map((t) => `${t.date},${t.distance},${t.duration}`).join("\n");
+    const csv = `date,distance,duration\n${rows}`;
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "summary.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleShare() {
+    navigator.clipboard?.writeText(window.location.href);
+  }
 
   return (
     <Card className="mb-4 animate-in fade-in">
       <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-1">
-          {loading && <Skeleton className="h-6 w-32" />}
-          {error && !loading && (
-            <div className="text-sm font-normal text-destructive">{error}</div>
-          )}
-          {!loading && !error && (
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            className="rounded-md p-1 text-sm"
+            value={range}
+            onChange={(e) => setRange(e.target.value)}
+          >
+            <option value="7">Last 7 days</option>
+            <option value="month">This month</option>
+            <option value="custom">Custom range</option>
+          </select>
+          {range === "custom" && (
             <>
-              <div className="text-2xl font-semibold">Weekly Totals</div>
-              <div className="text-sm font-normal text-muted-foreground">
-                {totalDistanceKm.toFixed(1)} km &bull; {totalSteps} steps &bull;{' '}
-                {totalSleep.toFixed(1)}h sleep
-              </div>
+              <input
+                type="date"
+                className="rounded-md p-1 text-sm"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+              <input
+                type="date"
+                className="rounded-md p-1 text-sm"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
             </>
           )}
         </div>
-        <div className="flex items-end gap-4">
-          {loading && (
-            <>
-              <Skeleton className="h-8 w-20" />
-              <Skeleton className="h-8 w-20" />
-            </>
-          )}
-          {!loading && !error && (
-            <>
-              <div className="h-8 w-20">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={stepsLast7} margin={{ top: 2, bottom: 2 }}>
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke="hsl(var(--primary))"
-                      fill="none"
-                      dot={false}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-              <div className="h-8 w-20">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={sleepLast7} margin={{ top: 2, bottom: 2 }}>
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke="hsl(var(--primary))"
-                      fill="none"
-                      dot={false}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-            </>
-          )}
-          {children}
+        <div className="flex items-center gap-2">
+          <button className="text-sm" onClick={() => quick("7")}>7 days</button>
+          <button className="text-sm" onClick={() => quick("30")}>30 days</button>
+          <button className="text-sm" onClick={() => quick("all")}>All time</button>
+          <button onClick={handleExport} className="p-1"><Download className="h-4 w-4" /></button>
+          <button onClick={handleShare} className="p-1"><Share2 className="h-4 w-4" /></button>
         </div>
       </CardHeader>
+      <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm font-normal text-muted-foreground">
+          {loading && <Skeleton className="h-6 w-32" />}
+          {error && !loading && <div className="text-destructive">{error}</div>}
+          {!loading && !error && (
+            <>
+              {totalDistanceKm.toFixed(1)} km &bull; {totalSteps} steps &bull; {" "}
+              {totalSleep.toFixed(1)}h sleep
+            </>
+          )}
+        </div>
+        {!loading && !error && (
+          <div className="flex items-end gap-4">
+            <div className="h-8 w-20">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={filteredSteps} margin={{ top: 2, bottom: 2 }}>
+                  <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill="none" dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="h-8 w-20">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={filteredSleep} margin={{ top: 2, bottom: 2 }}>
+                  <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill="none" dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+            {children}
+          </div>
+        )}
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- replace static weekly totals header with range selector, quick filters and export/share buttons
- move metrics and sparklines into card content
- document the new header features in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68884f1cd09c83249f6e122f6211a6c4