### PR TITLE
Refactor dashboard layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,9 @@
 import React from "react";
-import Header from "./components/Header";
 import DashboardPage from "./components/DashboardPage";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <Header />
       <main className="mx-auto max-w-[1200px]">
         <DashboardPage />
       </main>

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 import SummaryCard from "./SummaryCard";
 import KPIGrid from "./KPIGrid";
-import TrendsSection from "./TrendsSection";
+import StepsSparkline from "./StepsSparkline";
+import HRZonesBar from "./HRZonesBar";
+import TimeOfDay from "./TimeOfDay";
 import RunHeatmap from "./RunHeatmap";
 import CumulativeChart from "./CumulativeChart";
+import ChartCard from "./ChartCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
@@ -23,8 +26,15 @@ export default function DashboardPage() {
           </TabsList>
           <TabsContent value="dashboard" className="space-y-6">
             <KPIGrid />
-            <TrendsSection />
-            <RunHeatmap />
+            <div className="grid gap-6 sm:grid-cols-2">
+              <StepsSparkline />
+              <HRZonesBar />
+              <TimeOfDay />
+              <CumulativeChart />
+            </div>
+            <ChartCard title="Run Heatmap">
+              <RunHeatmap />
+            </ChartCard>
           </TabsContent>
           <TabsContent value="map" className="space-y-6">
             <React.Suspense

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -61,19 +61,16 @@ export default function KPIGrid() {
   }, []);
 
   return (
-    <div className="grid gap-10 sm:grid-cols-3 auto-rows-fr">
+    <div className="grid gap-6 sm:grid-cols-3 auto-rows-fr">
       {loading &&
         Array.from({ length: 3 }).map((_, i) => (
 
           <Card key={i} className="animate-in fade-in animate-pulse h-40">
 
-            <CardHeader className="items-center">
-              <CardTitle className="text-center">
-                <Skeleton className="h-6 w-24" />
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="flex items-center justify-center h-32">
+            <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
+              <Skeleton className="h-6 w-6" />
               <Skeleton className="h-20 w-20 rounded-full" />
+              <Skeleton className="h-4 w-20" />
             </CardContent>
           </Card>
         ))}
@@ -85,14 +82,10 @@ export default function KPIGrid() {
 
           <Card key={item.label} className="animate-in fade-in h-40">
 
-            <CardHeader className="items-center">
-              <CardTitle className="flex items-center gap-2 text-center">
-                {item.icon && <item.icon />}
-                {item.label}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="flex items-center justify-center h-32">
+            <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
+              {item.icon && <item.icon className="h-6 w-6" />}
               <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
+              <div className="text-sm font-medium text-center">{item.label}</div>
             </CardContent>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- place weekly totals header inside DashboardPage
- update KPIGrid cards to center icons and values
- arrange chart cards in a 2x2 grid with full‑width heatmap card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68884fe255b083249a7b24f43dff4bba