### PR TITLE
Enhance Weekly Totals card

### DIFF
--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -30,11 +30,18 @@ export default function WeeklySummaryCard({ children }) {
   const stepsLast7 = steps.slice(-7);
   const sleepLast7 = sleep.slice(-7);
   const totalsLast7 = totals.slice(-7);
+  const totalsPrev7 = totals.slice(-14, -7);
 
   const totalSteps = stepsLast7.reduce((sum, p) => sum + p.value, 0);
   const totalSleep = sleepLast7.reduce((sum, p) => sum + p.value, 0);
   const totalDistanceKm =
     totalsLast7.reduce((sum, p) => sum + p.distance, 0) / 1000;
+  const prevDistanceKm =
+    totalsPrev7.reduce((sum, p) => sum + p.distance, 0) / 1000;
+  const distanceChange = prevDistanceKm
+    ? ((totalDistanceKm - prevDistanceKm) / prevDistanceKm) * 100
+    : 0;
+  const arrow = distanceChange >= 0 ? "▲" : "▼";
 
   return (
     <Card className="mb-4 animate-in fade-in">
@@ -50,6 +57,12 @@ export default function WeeklySummaryCard({ children }) {
               <div className="text-sm font-normal text-muted-foreground">
                 {totalDistanceKm.toFixed(1)} km &bull; {totalSteps} steps &bull;{' '}
                 {totalSleep.toFixed(1)}h sleep
+              </div>
+              <div className="flex items-center gap-1 text-xs font-normal text-muted-foreground">
+                <span>
+                  {arrow} {Math.abs(distanceChange).toFixed(1)}%
+                </span>
+                <span className="rounded bg-muted px-1 py-0.5">vs last week</span>
               </div>
             </>
           )}
@@ -69,7 +82,7 @@ export default function WeeklySummaryCard({ children }) {
                     <Line
                       type="monotone"
                       dataKey="value"
-                      stroke="hsl(var(--primary))"
+                      stroke="hsl(var(--accent))"
                       fill="none"
                       dot={false}
                     />
@@ -82,7 +95,20 @@ export default function WeeklySummaryCard({ children }) {
                     <Line
                       type="monotone"
                       dataKey="value"
-                      stroke="hsl(var(--primary))"
+                      stroke="hsl(var(--accent))"
+                      fill="none"
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="h-8 w-20">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={totalsLast7} margin={{ top: 2, bottom: 2 }}>
+                    <Line
+                      type="monotone"
+                      dataKey="distance"
+                      stroke="hsl(var(--accent))"
                       fill="none"
                       dot={false}
                     />

--- a/frontend/src/components/__tests__/WeeklySummaryCard.test.jsx
+++ b/frontend/src/components/__tests__/WeeklySummaryCard.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import WeeklySummaryCard from '../WeeklySummaryCard';
+import { vi } from 'vitest';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 100, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+it('shows distance trend vs last week', async () => {
+  const steps = Array.from({ length: 14 }, (_, i) => ({
+    timestamp: `2023-01-${String(i + 1).padStart(2, '0')}T00:00:00`,
+    value: 1000,
+  }));
+  const sleep = Array.from({ length: 14 }, (_, i) => ({
+    timestamp: `2023-01-${String(i + 1).padStart(2, '0')}T00:00:00`,
+    value: 6,
+  }));
+  const totals = Array.from({ length: 14 }, (_, i) => ({
+    date: `2023-01-${String(i + 1).padStart(2, '0')}`,
+    distance: i < 7 ? 1000 : 2000,
+    duration: 0,
+  }));
+
+  global.fetch = vi.fn((url) => {
+    if (url === '/steps') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(steps) });
+    }
+    if (url === '/sleep') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(sleep) });
+    }
+    if (url === '/daily-totals') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(totals) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+  });
+
+  render(<WeeklySummaryCard />);
+  await screen.findByText(/vs last week/);
+  expect(screen.getByText('▲ 100.0%')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add context metrics and trending indicator on WeeklySummaryCard
- show sparklines in accent color
- test WeeklySummaryCard rendering

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68884f449a5483248986fa485dee9ea3