### PR TITLE
Move run summary to separate card

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 import SummaryCard from "./SummaryCard";
+import { Card, CardContent } from "./ui/Card";
 import KPIGrid from "./KPIGrid";
 import StepsSparkline from "./StepsSparkline";
 import HRZonesBar from "./HRZonesBar";
@@ -16,7 +17,9 @@ export default function DashboardPage() {
   return (
     <div className="space-y-6 p-6">
       <WeeklySummaryCard />
-      <SummaryCard>
+      <SummaryCard />
+      <Card className="animate-in fade-in">
+        <CardContent className="space-y-6">
         <Tabs defaultValue="dashboard" className="space-y-6">
           <TabsList className="grid w-full grid-cols-4 mb-4">
             <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
@@ -62,7 +65,8 @@ export default function DashboardPage() {
             <CumulativeChart />
           </TabsContent>
         </Tabs>
-      </SummaryCard>
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update DashboardPage to render run summary separately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688853a257e88324993840197aa458d5