### PR TITLE
Refine card styling and typography

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -45,7 +45,7 @@ export default function AnalysisSection() {
           {!loading && !error && (
             <ResponsiveContainer width="100%" height="100%">
               <ScatterChart>
-                <CartesianGrid />
+                <CartesianGrid stroke="#E5E7EB" strokeWidth={1} />
                 <XAxis dataKey="temperature" name="Temp" unit="°C" />
                 <YAxis dataKey="avgPace" name="Pace" unit="min/km" />
                 <Tooltip content={<AnalysisTooltip />} />

--- a/frontend/src/components/CumulativeChart.jsx
+++ b/frontend/src/components/CumulativeChart.jsx
@@ -76,7 +76,7 @@ export default function CumulativeChart() {
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-              <CartesianGrid stroke="hsl(var(--muted))" strokeDasharray="3 3" horizontal={false} />
+              <CartesianGrid stroke="#E5E7EB" strokeWidth={1} horizontal={false} />
               <XAxis dataKey="month" />
               <YAxis unit="km" />
               <Tooltip formatter={(v) => `${v.toFixed(1)} km`} />

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -64,7 +64,7 @@ export default function ElevationChart({ points = [], activeIndex = null }) {
       <div className="h-40">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" />
+            <CartesianGrid stroke="#E5E7EB" strokeWidth={1} strokeDasharray="4 4" />
             <XAxis dataKey="dist" unit="km" />
             <YAxis dataKey="elevation" unit="m" />
             <Tooltip content={<ElevationTooltip />} />

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -85,7 +85,7 @@ export default function KPIGrid() {
             <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
               {item.icon && <item.icon className="h-6 w-6" />}
               <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
-              <div className="text-sm font-medium text-center">{item.label}</div>
+              <div className="text-sm font-medium text-gray-500 text-center">{item.label}</div>
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/components/StepsSparkline.jsx
+++ b/frontend/src/components/StepsSparkline.jsx
@@ -55,7 +55,7 @@ export default function StepsSparkline() {
         {!loading && !error && (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={steps} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-              <CartesianGrid stroke="hsl(var(--muted))" strokeDasharray="3 3" />
+              <CartesianGrid stroke="#E5E7EB" strokeWidth={1} strokeDasharray="4 4" />
               <XAxis dataKey="timestamp" tick={false} />
               <YAxis />
               <Tooltip content={<StepTooltip />} />

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -4,7 +4,7 @@ export function Card({ className = "", children }) {
   return (
     <div
       className={
-        "rounded-xl border bg-card text-card-foreground shadow-sm transition-shadow transition-transform hover:-translate-y-0.5 hover:shadow-lg focus-within:shadow-md hover:border-accent " +
+        "rounded-xl bg-card text-card-foreground shadow-[0_1px_4px_rgba(0,0,0,0.05)] transition-shadow transition-transform hover:-translate-y-0.5 hover:shadow-lg focus-within:shadow-md " +
         className
       }
     >

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -43,7 +43,7 @@ export default function ProgressRing({
         </RadialBarChart>
       </ResponsiveContainer>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-3xl font-extrabold leading-none">{value}</span>
+        <span className="text-[2rem] font-bold leading-none">{value}</span>
         {unit && (
           <span className="text-xs text-muted-foreground">{unit}</span>
         )}

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -38,9 +38,8 @@ export function TabsTrigger({ value, className = "", children }) {
       className={
         "px-3 py-1.5 text-sm border-b-2 transition-colors " +
         (active
-          ? "border-accent text-accent-foreground"
-          : "border-transparent hover:border-accent hover:bg-accent/10") +
-        (active ? "" : "") +
+          ? "border-accent text-primary"
+          : "border-transparent text-gray-600 hover:border-accent") +
         " " +
         className
       }


### PR DESCRIPTION
## Summary
- soften card borders and add subtle drop shadow
- tweak KPI labels and gauge text
- lighten grid lines in charts
- simplify tab active state styling

## Testing
- `npm test --silent`
- `python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip >/tmp/pip.log && pip install -r requirements.txt >/tmp/pip.log && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688855f812188324bc0d40d22b47fe10