### PR TITLE
Reduce KPI gauge size

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -84,7 +84,13 @@ export default function KPIGrid() {
 
             <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
               {item.icon && <item.icon className="h-6 w-6" />}
-              <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
+              <ProgressRing
+                value={item.value}
+                max={item.goal}
+                unit={item.unit}
+                size={48}
+                thickness={15}
+              />
               <div className="text-sm font-medium text-gray-500 text-center">{item.label}</div>
             </CardContent>
           </Card>

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -5,6 +5,7 @@ export default function ProgressRing({
   value = 0,
   max = 100,
   size = 40,
+  thickness = 30,
   unit = "",
   className = "",
 }) {
@@ -19,7 +20,7 @@ export default function ProgressRing({
           data={data}
           cx="50%"
           cy="50%"
-          innerRadius="70%"
+          innerRadius={`${100 - thickness}%`}
           outerRadius="100%"
           startAngle={90}
           endAngle={-270}


### PR DESCRIPTION
## Summary
- shrink KPI progress rings to size=48
- expose `thickness` prop in `ProgressRing` and reduce ring width

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885b5fb158832485d20d8e7775a76a