### PR TITLE
Move DemoCharts to analysis tab

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -4,6 +4,7 @@ import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Responsive
 import { fetchAnalysis } from "../api";
 import Skeleton from "./ui/Skeleton";
 import TimeOfDay from "./TimeOfDay";
+import DemoCharts from "./DemoCharts/DemoCharts";
 
 function AnalysisTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
@@ -35,7 +36,8 @@ export default function AnalysisSection() {
   }, []);
 
   return (
-    <div className="grid gap-10 sm:grid-cols-2">
+    <div className="space-y-10">
+      <div className="grid gap-10 sm:grid-cols-2">
       <ChartCard title="Pace vs Temperature">
         <div className="h-64">
           {loading && <Skeleton className="h-full w-full" />}
@@ -59,7 +61,9 @@ export default function AnalysisSection() {
           )}
         </div>
       </ChartCard>
-      <TimeOfDay />
+        <TimeOfDay />
+      </div>
+      <DemoCharts />
     </div>
   );
 }

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -6,10 +6,8 @@ import KPIGrid from "./KPIGrid";
 import StepsSparkline from "./StepsSparkline";
 import HRZonesBar from "./HRZonesBar";
 import TimeOfDay from "./TimeOfDay";
-import RunHeatmap from "./RunHeatmap";
 import CumulativeChart from "./CumulativeChart";
 import ChartCard from "./ChartCard";
-import DemoCharts from "./DemoCharts/DemoCharts";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
@@ -36,10 +34,7 @@ export default function DashboardPage() {
               <TimeOfDay />
               <CumulativeChart />
             </div>
-            <ChartCard title="Run Heatmap">
-              <RunHeatmap />
-            </ChartCard>
-            <DemoCharts />
+
           </TabsContent>
           <TabsContent value="map" className="space-y-6">
             <React.Suspense


### PR DESCRIPTION
## Summary
- show treadmill/outdoor pie and radar charts in Analysis
- drop Run Heatmap and DemoCharts from the Dashboard tab

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68885c633bdc8324b84fb67b27162e42