### PR TITLE
Remove demo text and charts

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -1,68 +1,10 @@
 import React from "react";
-import ChartCard from "./ChartCard";
-import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
-import { fetchAnalysis } from "../api";
-import Skeleton from "./ui/Skeleton";
-import TimeOfDay from "./TimeOfDay";
 import DemoCharts from "./DemoCharts/DemoCharts";
 
-function AnalysisTooltip({ active, payload }) {
-  if (!active || !payload?.length) return null;
-  const { temperature, avgPace } = payload[0].payload;
-  return (
-    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
-      <div className="flex items-center gap-1">
-        <span>🌡️</span>
-        <span>{temperature}°C</span>
-      </div>
-      <div className="flex items-center gap-1">
-        <span>⏱</span>
-        <span>{avgPace} min/km</span>
-      </div>
-    </div>
-  );
-}
-
 export default function AnalysisSection() {
-  const [data, setData] = React.useState([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(null);
-
-  React.useEffect(() => {
-    fetchAnalysis()
-      .then(setData)
-      .catch(() => setError("Failed to load"))
-      .finally(() => setLoading(false));
-  }, []);
 
   return (
     <div className="space-y-10">
-      <div className="grid gap-10 sm:grid-cols-2">
-      <ChartCard title="Pace vs Temperature">
-        <div className="h-64">
-          {loading && <Skeleton className="h-full w-full" />}
-          {error && (
-            <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">{error}</div>
-          )}
-          {!loading && !error && (
-            <ResponsiveContainer width="100%" height="100%">
-              <ScatterChart>
-                <CartesianGrid stroke="#E5E7EB" strokeWidth={1} />
-                <XAxis dataKey="temperature" name="Temp" unit="°C" />
-                <YAxis dataKey="avgPace" name="Pace" unit="min/km" />
-                <Tooltip content={<AnalysisTooltip />} />
-                <Scatter
-                  data={data}
-                  fill="hsl(var(--primary))"
-                  isAnimationActive={false}
-                />
-              </ScatterChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </ChartCard>
-        <TimeOfDay />
-      </div>
       <DemoCharts />
     </div>
   );

--- a/frontend/src/components/DemoCharts/DemoCharts.jsx
+++ b/frontend/src/components/DemoCharts/DemoCharts.jsx
@@ -16,7 +16,6 @@ export default function DemoCharts() {
       {/* 1) Donut */}
       <div className="text-center">
         <h2 className="text-lg font-semibold">TREADMILL VS OUTDOOR</h2>
-        <p className="text-sm opacity-60">i’ll always run outside if i have a choice…</p>
         <div className="relative mx-auto" style={{ width: 200, height: 200 }}>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
@@ -43,7 +42,6 @@ export default function DemoCharts() {
         {/* 2) Activity by Time */}
         <div className="text-center">
           <h2 className="text-lg font-semibold">WORKOUT ACTIVITY BY TIME</h2>
-          <p className="text-sm opacity-60">definitely a morning runner…</p>
           <div style={{ width: '100%', height: 250 }}>
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={timeData}>
@@ -59,7 +57,6 @@ export default function DemoCharts() {
         {/* 3) Mileage by Day */}
         <div className="text-center">
           <h2 className="text-lg font-semibold">AVERAGE DAILY MILEAGE BY DAY</h2>
-          <p className="text-sm opacity-60">used to do my long runs on Saturdays…</p>
           <div style={{ width: '100%', height: 250 }}>
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={mileageData}>


### PR DESCRIPTION
## Summary
- clean up demo chart text strings
- simplify Analysis section to only render DemoCharts

## Testing
- `npm test --silent`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885dbc34c083248f0095d0c7dfa3b2