### PR TITLE
Add weather charts to analysis tab

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -5,6 +5,7 @@ import { fetchAnalysis } from "../api";
 import Skeleton from "./ui/Skeleton";
 import TimeOfDay from "./TimeOfDay";
 import DemoCharts from "./DemoCharts/DemoCharts";
+import DemoWeatherCharts from "./DemoWeatherCharts";
 
 function AnalysisTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
@@ -64,6 +65,7 @@ export default function AnalysisSection() {
         <TimeOfDay />
       </div>
       <DemoCharts />
+      <DemoWeatherCharts />
     </div>
   );
 }

--- a/frontend/src/components/DemoWeatherCharts.jsx
+++ b/frontend/src/components/DemoWeatherCharts.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  BarChart, Bar,
+  XAxis, YAxis, Tooltip,
+} from 'recharts';
+import {
+  Thermometer, Cloud, Sun, CloudRain, CloudSnow,
+  CloudHaze, Droplet, CloudFog, Zap,
+} from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
+import { temperatureData, weatherData } from './DemoWeatherData';
+
+export default function DemoWeatherCharts() {
+  return (
+    <div className="space-y-8">
+      {/* Temperature Chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Temperature</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            i prefer running in the 40s, but unfortunately i don\u2019t control the weather
+          </p>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={350}>
+            <BarChart
+              layout="vertical"
+              data={temperatureData}
+              margin={{ left: 100, right: 20, top: 20, bottom: 20 }}
+            >
+              <XAxis type="number" hide />
+              <YAxis
+                type="category"
+                dataKey="label"
+                width={100}
+                tickLine={false}
+                axisLine={false}
+                tick={({ x, y, payload }) => (
+                  <text
+                    x={x - 8}
+                    y={y + 4}
+                    textAnchor="end"
+                    fontSize={12}
+                    fill="#334155"
+                  >
+                    {payload.value}
+                    <tspan fill="#64748B">  {temperatureData.find(d => d.label === payload.value).range}</tspan>
+                  </text>
+                )}
+              />
+              <Tooltip
+                formatter={(val) => [`${val} runs`, ""]}
+                cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}
+              />
+              <Bar
+                dataKey="count"
+                fill="#94A3B8"
+                barSize={20}
+                radius={[4, 4, 4, 4]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* Weather Conditions Chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Weather Conditions</CardTitle>
+          <p className="text-sm text-muted-foreground">rain or shine!</p>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={350}>
+            <BarChart
+              layout="vertical"
+              data={weatherData}
+              margin={{ left: 120, right: 20, top: 20, bottom: 20 }}
+            >
+              <XAxis type="number" hide />
+              <YAxis
+                type="category"
+                dataKey="condition"
+                width={120}
+                tickLine={false}
+                axisLine={false}
+                tick={({ x, y, payload }) => {
+                  const Icon = weatherData.find(d => d.condition === payload.value).icon;
+                  return (
+                    <g transform={`translate(${x - 40},${y - 10})`}>
+                      <Icon size={16} fill="none" stroke="#334155" />
+                      <text x={24} y={16} fontSize={12} fill="#334155">
+                        {payload.value}
+                      </text>
+                    </g>
+                  );
+                }}
+              />
+              <Tooltip
+                formatter={(val) => [`${val} runs`, ""]}
+                cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}
+              />
+              <Bar
+                dataKey="count"
+                fill="#CBD5E1"
+                barSize={20}
+                radius={[4, 4, 4, 4]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/DemoWeatherData.js
+++ b/frontend/src/components/DemoWeatherData.js
@@ -1,0 +1,35 @@
+// src/components/DemoWeatherData.js
+import {
+  Cloud,
+  Sun,
+  CloudRain,
+  CloudSnow,
+  CloudHaze,
+  Droplet,
+  CloudFog,
+  Zap,
+} from 'lucide-react';
+
+export const temperatureData = [
+  { label: 'Frigid',      range: '<\u202f20\u00b0F', count: 57 },
+  { label: 'Very\u202fCold',   range: '20-29\u00b0F', count: 147 },
+  { label: 'Cold',        range: '30-39\u00b0F', count: 340 },
+  { label: 'Cool',        range: '40-49\u00b0F', count: 586 },
+  { label: 'Mild',        range: '50-59\u00b0F', count: 843 },
+  { label: 'Comfortable', range: '60-69\u00b0F', count: 758 },
+  { label: 'Warm',        range: '70-79\u00b0F', count: 427 },
+  { label: 'Hot',         range: '80-89\u00b0F', count: 89 },
+  { label: 'Very\u202fHot',    range: '\u2265\u202f90\u00b0F', count: 4 },
+];
+
+export const weatherData = [
+  { condition: 'Clouds', count: 1530, icon: Cloud },
+  { condition: 'Clear', count: 1131, icon: Sun },
+  { condition: 'Rain', count: 422, icon: CloudRain },
+  { condition: 'Snow', count: 77, icon: CloudSnow },
+  { condition: 'Haze', count: 60, icon: CloudHaze },
+  { condition: 'Drizzle', count: 18, icon: Droplet },
+  { condition: 'Fog', count: 8, icon: CloudFog },
+  { condition: 'Smoke', count: 3, icon: Cloud },
+  { condition: 'Thunderstorm', count: 1, icon: Zap },
+];


### PR DESCRIPTION
## Summary
- add `DemoWeatherCharts` component showing temperature and weather histograms
- include weather chart data in a dedicated module
- load new charts in the Analysis tab

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885e01c2f083249aee1b36d849d785