### PR TITLE
Add map and distance sparkline to run summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,9 @@ hours and daily totals using the API helpers. The header now offers a date range
 selector, quick filter buttons and export/share actions while the metrics and
 sparklines sit in the card content below.
 
+## Run Summary Card
+
+`frontend/src/components/SummaryCard.jsx` presents overall run statistics. It
+now includes a mini map for the most recent run and a small distance sparkline
+to visualize trends.
+

--- a/frontend/src/components/__tests__/SummaryCard.test.jsx
+++ b/frontend/src/components/__tests__/SummaryCard.test.jsx
@@ -2,6 +2,29 @@ import { render, screen } from '@testing-library/react';
 import SummaryCard, { computeSummary } from '../SummaryCard';
 import { vi } from 'vitest';
 
+vi.mock('../TrackMap', () => ({ default: () => <div data-testid="track" /> }));
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 100, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
 it('computeSummary totals runs and streak', () => {
   const data = [
     { date: '2023-01-03', distance: 1000, duration: 300 },
@@ -20,9 +43,20 @@ it('renders totals from API data', async () => {
     { date: '2023-01-01', distance: 5000, duration: 1800 },
     { date: '2023-01-02', distance: 6000, duration: 1800 },
   ];
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve(runs),
+  global.fetch = vi.fn((url) => {
+    if (url === '/runs') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(runs) });
+    }
+    if (url.startsWith('/activities?')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{ activityId: 'a1' }]),
+      });
+    }
+    if (url === '/activities/a1/track') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
   });
 
   render(<SummaryCard />);


### PR DESCRIPTION
## Summary
- enhance `SummaryCard` with track map and distance sparkline
- mock TrackMap and ResizeObserver in SummaryCard tests
- document new run summary visuals in README

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68885f06e48083249e18c3870753e6f3