### PR TITLE
Add daily step progress ring

### DIFF
--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -8,6 +8,9 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Download, Share2, ArrowUpRight, ArrowDownRight } from "lucide-react";
+import ProgressRing from "./ui/ProgressRing";
+
+const STEP_GOAL = 10000;
 
 export function computeStats(currSteps = [], prevSteps = [], currSleep = [], prevSleep = [], currTotals = [], prevTotals = []) {
   const sum = (arr, key) => arr.reduce((s, p) => s + (p[key] || 0), 0);
@@ -40,6 +43,8 @@ export default function WeeklySummaryCard({ children }) {
   const [range, setRange] = React.useState("7");
   const [startDate, setStartDate] = React.useState("");
   const [endDate, setEndDate] = React.useState("");
+
+  const todaySteps = steps[steps.length - 1]?.value ?? 0;
 
   React.useEffect(() => {
     Promise.all([fetchSteps(), fetchSleep(), fetchDailyTotals()])
@@ -249,6 +254,7 @@ export default function WeeklySummaryCard({ children }) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
+            <ProgressRing value={todaySteps} max={STEP_GOAL} size={60} />
             {children}
           </div>
         )}

--- a/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
+++ b/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
@@ -31,3 +31,10 @@ it('renders radial bar chart and displays value', () => {
   // The numeric value should appear in the overlay
   expect(getByText('50')).toBeInTheDocument();
 });
+
+it('shows unit label when provided', () => {
+  const { getByText } = render(
+    <ProgressRing value={3000} max={10000} unit="steps" />
+  );
+  expect(getByText('steps')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- use ProgressRing in WeeklySummaryCard
- display today's step count vs a 10k goal
- test ProgressRing unit label

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888bc4fdeec832483ed7e845f19cd93