### PR TITLE
Implement area sparkline

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,6 @@ and sparklines sit in the card content below.
 ## Run Summary Card
 
 `frontend/src/components/SummaryCard.jsx` presents overall run statistics. It
-now includes a mini map for the most recent run and a small distance sparkline
-to visualize trends.
+now includes a mini map for the most recent run and a small filled distance
+sparkline to visualize trends.
 

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -8,8 +8,8 @@ import {
   fetchActivityTrack,
 } from "../api";
 import {
-  LineChart,
-  Line,
+  AreaChart,
+  Area,
   ResponsiveContainer,
 } from "recharts";
 import { parseISO, differenceInCalendarDays } from "date-fns";
@@ -100,14 +100,16 @@ export default function SummaryCard({ children }) {
             {distanceData.length > 0 && (
               <div className="h-32 sm:w-1/3">
                 <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={distanceData} margin={{ top: 2, bottom: 2 }}>
-                    <Line
+                  <AreaChart data={distanceData} margin={{ top: 2, bottom: 2 }}>
+                    <Area
                       type="monotone"
                       dataKey="km"
                       stroke="hsl(var(--primary))"
+                      fill="hsl(var(--primary) / 0.2)"
+                      strokeWidth={2}
                       dot={false}
                     />
-                  </LineChart>
+                  </AreaChart>
                 </ResponsiveContainer>
               </div>
             )}


### PR DESCRIPTION
## Summary
- add an `AreaChart` in `SummaryCard` for a filled sparkline
- document the updated look of the Run Summary Card in `README`

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888bde777288324a917682a2a8084ca