### PR TITLE
Show daily distance goal in summary card

### DIFF
--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -11,6 +11,7 @@ import { Download, Share2, ArrowUpRight, ArrowDownRight } from "lucide-react";
 import ProgressRing from "./ui/ProgressRing";
 
 const STEP_GOAL = 10000;
+const DISTANCE_GOAL_KM = 20;
 
 export function computeStats(currSteps = [], prevSteps = [], currSleep = [], prevSleep = [], currTotals = [], prevTotals = []) {
   const sum = (arr, key) => arr.reduce((s, p) => s + (p[key] || 0), 0);
@@ -45,7 +46,8 @@ export default function WeeklySummaryCard({ children }) {
   const [startDate, setStartDate] = React.useState("");
   const [endDate, setEndDate] = React.useState("");
 
-  const todaySteps = steps[steps.length - 1]?.value ?? 0;
+  const todayDistanceKm =
+    (totals[totals.length - 1]?.distance ?? 0) / 1000;
 
   React.useEffect(() => {
     Promise.all([fetchSteps(), fetchSleep(), fetchDailyTotals()])
@@ -267,7 +269,13 @@ export default function WeeklySummaryCard({ children }) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <ProgressRing value={todaySteps} max={STEP_GOAL} size={60} />
+            <ProgressRing
+              value={todayDistanceKm}
+              max={DISTANCE_GOAL_KM}
+              unit="km"
+              title="Distance today"
+              size={60}
+            />
             {children}
           </div>
         )}

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -7,13 +7,18 @@ export default function ProgressRing({
   size = 40,
   unit = "",
   className = "",
+  title = "",
 }) {
   const percent = Math.max(0, Math.min(1, value / max)) * 100;
   const data = [{ name: "progress", value: percent }];
   const gradientId = React.useId();
 
   return (
-    <div className={"relative " + className} style={{ width: size, height: size }}>
+    <div
+      className={"relative " + className}
+      style={{ width: size, height: size }}
+      title={title}
+    >
       <ResponsiveContainer width="100%" height="100%">
         <RadialBarChart
           data={data}


### PR DESCRIPTION
## Summary
- add DISTANCE_GOAL_KM constant in `WeeklySummaryCard`
- compute today's distance in km
- show new daily distance progress ring
- allow tooltip text in `ProgressRing`

## Testing
- `npm install` and `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6888c1c88d588324b323600f9da39234