### PR TITLE
Handle invalid date inputs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -226,11 +226,17 @@ async def all_routes(
             ]
 
     if startDate or endDate:
-        start = datetime.date.fromisoformat(startDate) if startDate else None
-        end = datetime.date.fromisoformat(endDate) if endDate else None
+        try:
+            start = datetime.date.fromisoformat(startDate) if startDate else None
+            end = datetime.date.fromisoformat(endDate) if endDate else None
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid date")
 
         def in_range(act):
-            d = datetime.date.fromisoformat(act["startTimeLocal"].split("T")[0])
+            try:
+                d = datetime.date.fromisoformat(act["startTimeLocal"].split("T")[0])
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid date")
             if start and d < start:
                 return False
             if end and d > end:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -112,6 +112,11 @@ def test_routes_filtering():
     assert len(data) == 20
 
 
+def test_routes_invalid_start_date():
+    resp = client.get('/routes?startDate=bad-date')
+    assert resp.status_code == 400
+
+
 def test_daily_totals_endpoint():
     resp = client.get('/daily-totals')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- handle ValueError when parsing ISO dates in `/routes`
- test invalid startDate returns 400

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c342920c83249171745c7696c709