### PR TITLE
Ensure mocks restored after each test

### DIFF
--- a/frontend/src/components/__tests__/ActivityCalendar.test.jsx
+++ b/frontend/src/components/__tests__/ActivityCalendar.test.jsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import ActivityCalendar from '../ActivityCalendar';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 it('renders month view and triggers selection', async () => {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,

--- a/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
+++ b/frontend/src/components/__tests__/CalendarHeatmap.test.jsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import CalendarHeatmap from '../CalendarHeatmap';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 it('renders squares with tooltip text', async () => {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,

--- a/frontend/src/components/__tests__/CumulativeChart.test.jsx
+++ b/frontend/src/components/__tests__/CumulativeChart.test.jsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import CumulativeChart from '../CumulativeChart';
 
+afterEach(() => vi.restoreAllMocks());
+
 beforeAll(() => {
   global.ResizeObserver = class {
     constructor(cb) {

--- a/frontend/src/components/__tests__/CumulativeTimeChart.test.jsx
+++ b/frontend/src/components/__tests__/CumulativeTimeChart.test.jsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import CumulativeTimeChart from '../CumulativeTimeChart';
 
+afterEach(() => vi.restoreAllMocks());
+
 beforeAll(() => {
   global.ResizeObserver = class {
     constructor(cb) {

--- a/frontend/src/components/__tests__/MapSection.test.jsx
+++ b/frontend/src/components/__tests__/MapSection.test.jsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import MapSection from '../MapSection';
 
+afterEach(() => vi.restoreAllMocks());
+
 vi.mock('../ActivityCalendar', () => ({ default: () => <div data-testid="calendar" /> }));
 vi.mock('../CalendarHeatmap', () => ({ default: () => <div data-testid="heatmap" /> }));
 vi.mock('../LeafletMap', () => ({ default: () => <div data-testid="leaflet" /> }));

--- a/frontend/src/components/__tests__/RunHeatmap.test.jsx
+++ b/frontend/src/components/__tests__/RunHeatmap.test.jsx
@@ -2,6 +2,8 @@ import { render, waitFor } from '@testing-library/react';
 import RunHeatmap from '../RunHeatmap';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 it('renders rects with tooltip data', async () => {
   const d1 = new Date();
   const d0 = new Date(Date.now() - 86400000);

--- a/frontend/src/components/__tests__/SummaryCard.test.jsx
+++ b/frontend/src/components/__tests__/SummaryCard.test.jsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import SummaryCard, { computeSummary } from '../SummaryCard';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 vi.mock('../TrackMap', () => ({ default: () => <div data-testid="track" /> }));
 
 beforeAll(() => {

--- a/frontend/src/components/__tests__/WeeklySummaryCard.test.jsx
+++ b/frontend/src/components/__tests__/WeeklySummaryCard.test.jsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import WeeklySummaryCard, { computeStats } from '../WeeklySummaryCard';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 beforeAll(() => {
   global.ResizeObserver = class {
     constructor(cb) {

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -1,6 +1,8 @@
 import { fetchRuns, fetchActivities } from '../../api';
 import { vi } from 'vitest';
 
+afterEach(() => vi.restoreAllMocks());
+
 test('fetchRuns returns parsed JSON', async () => {
   const data = [
     { date: '2023-01-01', distance: 5000, duration: 1800 },


### PR DESCRIPTION
## Summary
- restore global mocks after each frontend test

## Testing
- `npm test` in `frontend`
- `pytest` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6888d12a8f248324a90f0e92e252bf71