### PR TITLE
Fix failing build from missing icon

### DIFF
--- a/frontend/src/data/weather.js
+++ b/frontend/src/data/weather.js
@@ -1,6 +1,6 @@
 import {
   Cloud, Sun, CloudRain, CloudSnow,
-  CloudHaze, Droplet, CloudFog, Zap
+  Haze, Droplet, CloudFog, Zap
 } from "lucide-react"
 
 export const weatherData = [
@@ -8,7 +8,7 @@ export const weatherData = [
   { condition: "Clear",       count: 1131, icon: Sun },
   { condition: "Rain",        count: 422,  icon: CloudRain },
   { condition: "Snow",        count: 77,   icon: CloudSnow },
-  { condition: "Haze",        count: 60,   icon: CloudHaze },
+  { condition: "Haze",        count: 60,   icon: Haze },
   { condition: "Drizzle",     count: 18,   icon: Droplet },
   { condition: "Fog",         count: 8,    icon: CloudFog },
   { condition: "Smoke",       count: 3,    icon: Cloud },


### PR DESCRIPTION
## Summary
- correct 'CloudHaze' icon reference to `Haze`
- dependencies installed and tests pass

## Testing
- `npm test --silent`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888d37498b88324a9c3c57b31a0164f