### PR TITLE
Fix missing component imports

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -8,6 +8,8 @@ import CumulativeChart from "./CumulativeChart";
 import WeatherChart from "./WeatherChart";
 import TemperatureChart from "./TemperatureChart";
 import StatesVisited from "./StatesVisited";
+import WeeklySummaryCard from "./WeeklySummaryCard";
+import SummaryCard from "./SummaryCard";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
 


### PR DESCRIPTION
## Summary
- import `WeeklySummaryCard` and `SummaryCard` in DashboardPage

## Testing
- `cd frontend && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888e7a4d03c8324ac00034a1a21970d