### PR TITLE
Fix chart tick errors

### DIFF
--- a/frontend/src/components/DemoWeatherCharts.jsx
+++ b/frontend/src/components/DemoWeatherCharts.jsx
@@ -36,19 +36,23 @@ export default function DemoWeatherCharts() {
                 width={100}
                 tickLine={false}
                 axisLine={false}
-                tick={({ x, y, payload }) => (
-                  <text
-                    x={x - 8}
-                    y={y + 4}
-                    textAnchor="end"
-                    fontSize={12}
-                    fill="#334155"
-                  >
-                    {payload.value}
-                    <tspan fill="#64748B">  {temperatureData.find(d => d.label === payload.value).range}</tspan>
-                  </text>
-                )}
-              />
+                  tick={({ x, y, payload }) => {
+                    const entry = temperatureData.find(d => d.label === payload.value);
+                    const range = entry ? entry.range : "";
+                    return (
+                      <text
+                        x={x - 8}
+                        y={y + 4}
+                        textAnchor="end"
+                        fontSize={12}
+                        fill="#334155"
+                      >
+                        {payload.value}
+                        <tspan fill="#64748B">  {range}</tspan>
+                      </text>
+                    );
+                  }}
+                />
               <Tooltip
                 formatter={(val) => [`${val} runs`, ""]}
                 cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}
@@ -84,18 +88,21 @@ export default function DemoWeatherCharts() {
                 width={120}
                 tickLine={false}
                 axisLine={false}
-                tick={({ x, y, payload }) => {
-                  const Icon = weatherData.find(d => d.condition === payload.value).icon;
-                  return (
-                    <g transform={`translate(${x - 40},${y - 10})`}>
-                      <Icon size={16} fill="none" stroke="#334155" />
-                      <text x={24} y={16} fontSize={12} fill="#334155">
-                        {payload.value}
-                      </text>
-                    </g>
-                  );
-                }}
-              />
+                  tick={({ x, y, payload }) => {
+                    const entry = weatherData.find(d => d.condition === payload.value);
+                    const Icon = entry ? entry.icon : null;
+                    return (
+                      <g transform={`translate(${x - 40},${y - 10})`}>
+                        {Icon && (
+                          <Icon size={16} fill="none" stroke="#334155" />
+                        )}
+                        <text x={24} y={16} fontSize={12} fill="#334155">
+                          {payload.value}
+                        </text>
+                      </g>
+                    );
+                  }}
+                />
               <Tooltip
                 formatter={(val) => [`${val} runs`, ""]}
                 cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}

--- a/frontend/src/components/TemperatureChart.jsx
+++ b/frontend/src/components/TemperatureChart.jsx
@@ -34,7 +34,8 @@ export default function TemperatureChart() {
               tickLine={false}
               axisLine={false}
               tick={({ x, y, payload }) => {
-                const { range } = temperatureData.find(d => d.label === payload.value);
+                const entry = temperatureData.find(d => d.label === payload.value);
+                const range = entry ? entry.range : "";
                 return (
                   <text
                     x={x - 8}

--- a/frontend/src/components/WeatherChart.jsx
+++ b/frontend/src/components/WeatherChart.jsx
@@ -29,10 +29,11 @@ export default function WeatherChart() {
               tickLine={false}
               axisLine={false}
               tick={({ x, y, payload }) => {
-                const Icon = weatherData.find(d => d.condition === payload.value).icon;
+                const entry = weatherData.find(d => d.condition === payload.value);
+                const Icon = entry ? entry.icon : null;
                 return (
                   <g transform={`translate(${x - 90},${y - 8})`}>
-                    <Icon size={16} stroke="#64748B" />
+                    {Icon && <Icon size={16} stroke="#64748B" />}
                     <text x={24} y={12} fill="#334155" fontSize={12}>
                       {payload.value}
                     </text>


### PR DESCRIPTION
## Summary
- avoid destructuring undefined in weather chart ticks
- render icons conditionally

## Testing
- `npm test` in `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f1d647188324baed8bb4ebcf4db6