### PR TITLE
Remove obsolete charts

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -1,68 +1,9 @@
 import React from "react";
-import ChartCard from "./ChartCard";
-import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
-import { fetchAnalysis } from "../api";
-import Skeleton from "./ui/Skeleton";
-import CumulativeTimeChart from "./CumulativeTimeChart";
 import DemoCharts from "./DemoCharts/DemoCharts";
 
-function AnalysisTooltip({ active, payload }) {
-  if (!active || !payload?.length) return null;
-  const { temperature, avgPace } = payload[0].payload;
-  return (
-    <div className="rounded border border-border bg-background p-2 text-sm font-normal shadow">
-      <div className="flex items-center gap-1">
-        <span>🌡️</span>
-        <span>{temperature}°C</span>
-      </div>
-      <div className="flex items-center gap-1">
-        <span>⏱</span>
-        <span>{avgPace} min/km</span>
-      </div>
-    </div>
-  );
-}
-
 export default function AnalysisSection() {
-  const [data, setData] = React.useState([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(null);
-
-  React.useEffect(() => {
-    fetchAnalysis()
-      .then(setData)
-      .catch(() => setError("Failed to load"))
-      .finally(() => setLoading(false));
-  }, []);
-
   return (
     <div className="space-y-10">
-      <div className="grid gap-10 sm:grid-cols-2">
-      <ChartCard title="Pace vs Temperature">
-        <div className="h-64">
-          {loading && <Skeleton className="h-full w-full" />}
-          {error && (
-            <div className="flex h-full items-center justify-center text-sm font-normal text-destructive">{error}</div>
-          )}
-          {!loading && !error && (
-            <ResponsiveContainer width="100%" height="100%">
-              <ScatterChart>
-                <CartesianGrid stroke="#E5E7EB" strokeWidth={1} />
-                <XAxis dataKey="temperature" name="Temp" unit="°C" />
-                <YAxis dataKey="avgPace" name="Pace" unit="min/km" />
-                <Tooltip content={<AnalysisTooltip />} />
-                <Scatter
-                  data={data}
-                  fill="hsl(var(--primary))"
-                  isAnimationActive={false}
-                />
-              </ScatterChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </ChartCard>
-        <CumulativeTimeChart />
-      </div>
       <DemoCharts />
     </div>
   );

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -2,9 +2,6 @@ import React from "react";
 import { Card, CardContent } from "./ui/Card";
 import KPIGrid from "./KPIGrid";
 import StepsSparkline from "./StepsSparkline";
-import HRZonesBar from "./HRZonesBar";
-import CumulativeTimeChart from "./CumulativeTimeChart";
-import CumulativeChart from "./CumulativeChart";
 import WeatherChart from "./WeatherChart";
 import TemperatureChart from "./TemperatureChart";
 import StatesVisited from "./StatesVisited";
@@ -25,9 +22,6 @@ export default function DashboardPage() {
         <CardContent className="space-y-6">
           <div className="grid gap-6 sm:grid-cols-2">
             <StepsSparkline />
-            <HRZonesBar />
-            <CumulativeTimeChart />
-            <CumulativeChart />
           </div>
           <React.Suspense
             fallback={
@@ -47,7 +41,6 @@ export default function DashboardPage() {
           >
             <AnalysisSection />
           </React.Suspense>
-          <CumulativeChart />
           <KPIGrid />
           <div className="grid gap-6 sm:grid-cols-2">
             <TemperatureChart />

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ChartCard from "./ChartCard";
 import ActivityCalendar from "./ActivityCalendar";
-import CalendarHeatmap from "./CalendarHeatmap";
 import { Card, CardContent } from "./ui/Card";
 import {
   fetchActivityTrack,
@@ -119,9 +118,6 @@ export default function MapSection() {
       {points.length > 0 && (
         <ElevationChart points={points} activeIndex={hoverIdx} />
       )}
-      <ChartCard title="On This Day">
-        <CalendarHeatmap />
-      </ChartCard>
       <ChartCard title="Route Heatmap">
         <div className="mb-2 flex flex-col gap-2 sm:flex-row">
           <select

--- a/frontend/src/components/TrendsSection.jsx
+++ b/frontend/src/components/TrendsSection.jsx
@@ -1,12 +1,10 @@
 import React from "react";
 import StepsSparkline from "./StepsSparkline";
-import HRZonesBar from "./HRZonesBar";
 
 export default function TrendsSection() {
   return (
     <div className="grid gap-10 sm:grid-cols-2">
       <StepsSparkline />
-      <HRZonesBar />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop Pace vs Temperature plot and related data handling
- remove Time Spent Running chart from dashboard
- remove HR Zones chart from dashboard and trends page
- drop Mileage Over Time chart from dashboard
- drop On This Day calendar from map section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f4e046408324869322717cf34958