### PR TITLE
Reorder dashboard sections

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -15,6 +15,24 @@ export default function DashboardPage() {
     <div className="space-y-6 p-6">
 
       <h2 className="text-sm font-medium text-gray-600 mb-2">Activity Overview</h2>
+
+      <React.Suspense
+        fallback={
+          <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
+            Loading analysis...
+          </div>
+        }
+      >
+        <AnalysisSection />
+      </React.Suspense>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <TemperatureChart />
+        <WeatherChart />
+      </div>
+
+      <StatesVisited />
+
       <WeeklySummaryCard />
       <SummaryCard />
 
@@ -32,23 +50,9 @@ export default function DashboardPage() {
           >
             <MapSection />
           </React.Suspense>
-          <React.Suspense
-            fallback={
-              <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
-                Loading analysis...
-              </div>
-            }
-          >
-            <AnalysisSection />
-          </React.Suspense>
           <KPIGrid />
-          <div className="grid gap-6 sm:grid-cols-2">
-            <TemperatureChart />
-            <WeatherChart />
-          </div>
         </CardContent>
       </Card>
-      <StatesVisited />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- rearrange dashboard to list analysis charts first
- show temperature and weather before states visited

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6888f9550f988324820bee4d00022c30