### PR TITLE
Add TodayDistanceSparkbar visualization

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -7,6 +7,7 @@ import TemperatureChart from "./TemperatureChart";
 import StatesVisited from "./StatesVisited";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 import SummaryCard from "./SummaryCard";
+import TodayDistanceCard from "./TodayDistanceCard";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
 
@@ -15,6 +16,7 @@ export default function DashboardPage() {
     <div className="space-y-6 p-6">
 
       <h2 className="text-sm font-medium text-gray-600 mb-2">Activity Overview</h2>
+      <TodayDistanceCard />
       <WeeklySummaryCard />
       <SummaryCard />
 

--- a/frontend/src/components/TodayDistanceCard.jsx
+++ b/frontend/src/components/TodayDistanceCard.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from './ui/Card'
+import Skeleton from './ui/Skeleton'
+import { fetchDailyTotals } from '../api'
+import { TodayDistanceSparkbar } from './ui/TodayDistanceSparkbar'
+
+export default function TodayDistanceCard() {
+  const [history, setHistory] = React.useState([])
+  const [today, setToday] = React.useState(0)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState(null)
+
+  React.useEffect(() => {
+    fetchDailyTotals()
+      .then((data) => {
+        const values = data
+          .slice(-8)
+          .map((t) => (t.distance ?? 0) / 1000)
+        setHistory(values)
+        setToday(values[values.length - 1] ?? 0)
+      })
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <Card className="animate-in fade-in">
+      <CardHeader>
+        <CardTitle>Distance Today</CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center justify-center">
+        {loading && <Skeleton className="h-8 w-20" />}
+        {error && !loading && (
+          <div className="text-sm font-normal text-destructive">{error}</div>
+        )}
+        {!loading && !error && (
+          <TodayDistanceSparkbar history={history} todayValue={today} />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -8,10 +8,9 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Download, Share2, ArrowUpRight, ArrowDownRight } from "lucide-react";
-import ProgressRing from "./ui/ProgressRing";
+import { TodayDistanceSparkbar } from "./ui/TodayDistanceSparkbar";
 
 const STEP_GOAL = 10000;
-const DISTANCE_GOAL_KM = 20;
 
 export function computeStats(currSteps = [], prevSteps = [], currSleep = [], prevSleep = [], currTotals = [], prevTotals = []) {
   const sum = (arr, key) => arr.reduce((s, p) => s + (p[key] || 0), 0);
@@ -48,6 +47,9 @@ export default function WeeklySummaryCard({ children }) {
 
   const todayDistanceKm =
     (totals[totals.length - 1]?.distance ?? 0) / 1000;
+  const distanceHistoryKm = totals
+    .slice(-8)
+    .map((t) => (t.distance ?? 0) / 1000);
 
   React.useEffect(() => {
     Promise.all([fetchSteps(), fetchSleep(), fetchDailyTotals()])
@@ -269,12 +271,9 @@ export default function WeeklySummaryCard({ children }) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <ProgressRing
-              value={todayDistanceKm}
-              max={DISTANCE_GOAL_KM}
-              unit="km"
-              title="Distance today"
-              size={60}
+            <TodayDistanceSparkbar
+              history={distanceHistoryKm}
+              todayValue={todayDistanceKm}
             />
             {children}
           </div>

--- a/frontend/src/components/__tests__/TodayDistanceCard.test.jsx
+++ b/frontend/src/components/__tests__/TodayDistanceCard.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import TodayDistanceCard from '../TodayDistanceCard'
+
+afterEach(() => vi.restoreAllMocks())
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 120, height: 32 } }])
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 120,
+    height: 32,
+    top: 0,
+    left: 0,
+    bottom: 32,
+    right: 120,
+  })
+})
+
+it('renders sparkbar from API data', async () => {
+  const totals = Array.from({ length: 8 }).map((_, i) => ({
+    date: `2023-01-0${i + 1}`,
+    distance: i * 1000,
+    duration: 0,
+  }))
+  global.fetch = vi.fn((url) => {
+    if (url === '/daily-totals') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(totals) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  })
+  const { container } = render(<TodayDistanceCard />)
+  await screen.findByText('Distance Today')
+  await waitFor(() => {
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/TodayDistanceSparkbar.jsx
+++ b/frontend/src/components/ui/TodayDistanceSparkbar.jsx
@@ -1,0 +1,20 @@
+import { BarChart, Bar, ReferenceLine, ResponsiveContainer, XAxis } from 'recharts'
+
+export function TodayDistanceSparkbar({ history, todayValue }) {
+  return (
+    <ResponsiveContainer width={120} height={32}>
+      <BarChart
+        data={history.map((d, i) => ({ index: i, v: d }))}
+        margin={{ top: 4, bottom: 4, left: 0, right: 0 }}
+      >
+        <XAxis dataKey="index" hide tick={false} />
+        <Bar dataKey="v" fill="hsl(var(--accent))" barSize={6} />
+        <ReferenceLine
+          x={history.length - 1}
+          stroke="hsl(var(--primary))"
+          strokeWidth={2}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/src/components/ui/__tests__/TodayDistanceSparkbar.test.jsx
+++ b/frontend/src/components/ui/__tests__/TodayDistanceSparkbar.test.jsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { TodayDistanceSparkbar } from '../TodayDistanceSparkbar'
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 120, height: 32 } }])
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 120,
+    height: 32,
+    top: 0,
+    left: 0,
+    bottom: 32,
+    right: 120,
+  })
+})
+
+it('renders sparkbar svg', () => {
+  const data = [1,2,3,4,5,6,7,8]
+  const { container } = render(
+    <TodayDistanceSparkbar history={data} todayValue={8} />
+  )
+  expect(container.querySelector('svg')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- add new `TodayDistanceSparkbar` component
- update weekly summary card to show sparkbar instead of ring
- test `TodayDistanceSparkbar`
- add `TodayDistanceCard` and show it first on the dashboard
- test `TodayDistanceCard`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f893b90083249ffdc505c5878e6c