### PR TITLE
Move summary card to top of dashboard

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -16,6 +16,8 @@ export default function DashboardPage() {
 
       <h2 className="text-sm font-medium text-gray-600 mb-2">Activity Overview</h2>
 
+      <WeeklySummaryCard />
+
       <React.Suspense
         fallback={
           <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
@@ -33,7 +35,6 @@ export default function DashboardPage() {
 
       <StatesVisited />
 
-      <WeeklySummaryCard />
       <SummaryCard />
 
       <Card className="animate-in fade-in">


### PR DESCRIPTION
## Summary
- place WeeklySummaryCard as the first component below Activity Overview

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68890754e5908324acaa3bb01f61d5a7