### PR TITLE
Update states legend with counts

### DIFF
--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -1,13 +1,17 @@
+import { states } from "@/data/states";
+
 export default function Legend() {
+  const visited = states.filter((s) => s.visited).length;
+  const notVisited = states.length - visited;
   return (
     <div className="flex items-center gap-4 mt-4 text-sm">
       <div className="flex items-center gap-1">
         <span className="w-4 h-4 bg-gray-200 border rounded-sm"></span>
-        <span>Not visited</span>
+        <span>Not visited ({notVisited})</span>
       </div>
       <div className="flex items-center gap-1">
         <span className="w-4 h-4 bg-foreground rounded-sm"></span>
-        <span>Visited</span>
+        <span>Visited ({visited})</span>
       </div>
     </div>
   );

--- a/frontend/src/components/StatesVisited.jsx
+++ b/frontend/src/components/StatesVisited.jsx
@@ -11,7 +11,7 @@ export default function StatesVisited() {
       <CardHeader className="text-center">
         <CardTitle>US STATES VISITED</CardTitle>
         <p className="text-sm text-muted-foreground">
-          {visitedCount} of 50 states visited, still a few to go
+          {visitedCount} of 50 states visited
         </p>
       </CardHeader>
       <CardContent className="lg:flex lg:gap-8">


### PR DESCRIPTION
## Summary
- show visited and not visited state counts in the legend
- update US states visited card caption

## Testing
- `cd frontend && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688907b54c8083249853cc62fe71540f