### PR TITLE
Ensure Inter font everywhere

### DIFF
--- a/frontend/src/components/StatesTable.jsx
+++ b/frontend/src/components/StatesTable.jsx
@@ -9,7 +9,8 @@ export default function StatesTable() {
   const renderRows = (list) =>
     list.map((s) => (
       <tr key={s.abbr} className="group hover:bg-gray-50">
-        <td className="py-2 px-4 font-mono text-sm cursor-pointer">› {s.name}</td>
+        {/* use the default sans-serif font (Inter) for consistency */}
+        <td className="py-2 px-4 text-sm cursor-pointer">› {s.name}</td>
         <td className="py-2 px-4 text-sm tabular-nums">{s.days}</td>
         <td className="py-2 px-4 text-sm tabular-nums">{s.miles.toFixed(1)}</td>
       </tr>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -24,7 +24,8 @@
 
 @layer base {
   body {
-    @apply leading-snug;
+    /* ensure all text uses the Inter font stack */
+    @apply font-sans leading-snug;
   }
 }
 


### PR DESCRIPTION
## Summary
- make Inter the global font in `globals.css`
- remove leftover `font-mono` usage

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `pytest -q`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890810cb648324bf38f5609a13ebc0