### PR TITLE
Unify dashboard palette

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -14,7 +14,7 @@ export default function DashboardPage() {
   return (
     <div className="space-y-6 p-6">
 
-      <h2 className="text-sm font-medium text-gray-600 mb-2">Activity Overview</h2>
+      <h2 className="text-sm font-medium text-muted-foreground mb-2">Activity Overview</h2>
 
       <WeeklySummaryCard />
 

--- a/frontend/src/components/DemoCharts/DemoCharts.jsx
+++ b/frontend/src/components/DemoCharts/DemoCharts.jsx
@@ -12,11 +12,11 @@ const MILEAGE_COLOR = '#FFB347';
 
 export default function DemoCharts() {
   return (
-    <div className="space-y-8 p-6 bg-gray-900 text-white rounded-xl relative">
+    <div className="space-y-8 p-6 bg-background text-foreground rounded-xl relative">
       {/* 1) Donut */}
       <div className="text-center">
         <h2 className="text-lg font-semibold">Treadmill vs Outdoor</h2>
-        <p className="text-sm text-gray-400">Andy runs inside a lot</p>
+        <p className="text-sm text-muted-foreground">Andy runs inside a lot</p>
         <div className="relative mx-auto" style={{ width: 200, height: 200 }}>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
@@ -43,7 +43,7 @@ export default function DemoCharts() {
         {/* 2) Activity by Time */}
         <div className="text-center">
           <h2 className="text-lg font-semibold">Workout Activity by Time</h2>
-          <p className="text-sm text-gray-400">Andy spends a lot of time doing this</p>
+          <p className="text-sm text-muted-foreground">Andy spends a lot of time doing this</p>
           <div style={{ width: '100%', height: 250 }}>
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={timeData}>
@@ -59,7 +59,7 @@ export default function DemoCharts() {
         {/* 3) Mileage by Day */}
         <div className="text-center">
           <h2 className="text-lg font-semibold">Average Daily Mileage by Day</h2>
-          <p className="text-sm text-gray-400">Andy probaly runs more on the weekend</p>
+          <p className="text-sm text-muted-foreground">Andy probaly runs more on the weekend</p>
           <div style={{ width: '100%', height: 250 }}>
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={mileageData}>

--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -85,7 +85,7 @@ export default function KPIGrid() {
             <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
               {item.icon && <item.icon className="h-6 w-6" />}
               <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
-              <div className="text-sm font-medium text-gray-500 text-center">{item.label}</div>
+              <div className="text-sm font-medium text-muted-foreground text-center">{item.label}</div>
             </CardContent>
           </Card>
         ))}

--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -6,7 +6,7 @@ export default function Legend() {
   return (
     <div className="flex items-center gap-4 mt-4 text-sm">
       <div className="flex items-center gap-1">
-        <span className="w-4 h-4 bg-gray-200 border rounded-sm"></span>
+        <span className="w-4 h-4 bg-muted border rounded-sm"></span>
         <span>Not visited ({notVisited})</span>
       </div>
       <div className="flex items-center gap-1">

--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -7,7 +7,7 @@ export default function StatesGrid() {
         <div
           key={s.abbr}
           style={{ gridColumn: s.col, gridRow: s.row }}
-          className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${s.visited ? "bg-foreground text-background" : "bg-gray-200 text-gray-400"}`}
+          className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${s.visited ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}
           title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
         >
           {s.abbr}

--- a/frontend/src/components/StatesTable.jsx
+++ b/frontend/src/components/StatesTable.jsx
@@ -8,7 +8,7 @@ export default function StatesTable() {
 
   const renderRows = (list) =>
     list.map((s) => (
-      <tr key={s.abbr} className="group hover:bg-gray-50">
+      <tr key={s.abbr} className="group hover:bg-muted">
         {/* use the default sans-serif font (Inter) for consistency */}
         <td className="py-2 px-4 text-sm cursor-pointer">› {s.name}</td>
         <td className="py-2 px-4 text-sm tabular-nums">{s.days}</td>

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -39,7 +39,7 @@ export function TabsTrigger({ value, className = "", children }) {
         "px-3 py-1.5 text-sm border-b-2 transition-colors " +
         (active
           ? "border-accent text-primary"
-          : "border-transparent text-gray-600 hover:border-accent") +
+          : "border-transparent text-muted-foreground hover:border-accent") +
         " " +
         className
       }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -3,17 +3,18 @@
 /* 1) Light‑mode defaults */
 :root {
   /* neutral black & white palette */
-  --background:         #ffffff;
-  --foreground:         #000000;
-  --accent:             #000000;
+  /* adopt the dark palette used in DemoCharts */
+  --background:         #111827; /* matches bg-gray-900 */
+  --foreground:         #ffffff; /* text-white */
+  --accent:             #3b82f6; /* blue accent for charts */
   --accent-foreground:  #ffffff;
 
-  /* set plugin variables to greyscale */
-  --primary:            0 0% 0%;
+  /* plugin variables tweaked for the dark theme */
+  --primary:            215 80% 56%;
   --primary-foreground: 0 0% 100%;
-  --secondary:          0 0% 100%;
-  --secondary-foreground: 0 0% 0%;
-  --destructive:        0 0% 0%;
+  --secondary:          222 47% 10%;
+  --secondary-foreground: 0 0% 100%;
+  --destructive:        0 84% 60%;
   --destructive-foreground: 0 0% 100%;
 }
 


### PR DESCRIPTION
## Summary
- switch global palette to the dark DemoCharts colors
- replace hardcoded gray classes with semantic classes
- keep card and tab styling consistent with new colors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68890a8da6a88324947b5da9e0894001