### PR TITLE
Add tooltip for mileage radar chart

### DIFF
--- a/frontend/src/components/DemoCharts/DemoCharts.jsx
+++ b/frontend/src/components/DemoCharts/DemoCharts.jsx
@@ -3,6 +3,7 @@ import {
   PieChart, Pie, Cell,
   RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar,
   ResponsiveContainer,
+  Tooltip,
 } from 'recharts';
 import { modeData, timeData, mileageData } from './data';
 
@@ -67,6 +68,7 @@ export default function DemoCharts() {
                 <PolarAngleAxis dataKey="day" stroke="#AAA" />
                 <PolarRadiusAxis angle={30} domain={[0, 6]} tick={false} />
                 <Radar name="mileage" dataKey="mi" stroke={MILEAGE_COLOR} fill={MILEAGE_COLOR} fillOpacity={0.6} />
+                <Tooltip formatter={(val) => [`${val} mi`, ""]} />
               </RadarChart>
             </ResponsiveContainer>
           </div>


### PR DESCRIPTION
## Summary
- import `Tooltip` in `DemoCharts`
- show mileage values on the "Average Daily Mileage by Day" radar chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890e63c9d4832485fe5f189b9348e3