### PR TITLE
Reorder progress ring in WeeklySummaryCard

### DIFF
--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -255,6 +255,13 @@ export default function WeeklySummaryCard({ children }) {
         </div>
         {!loading && !error && (
           <div className="flex items-end gap-4">
+            <ProgressRing
+              value={todayDistanceKm}
+              max={DISTANCE_GOAL_KM}
+              unit="km"
+              title="Distance today"
+              size={60}
+            />
             <div className="h-8 w-20">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={filteredSteps} margin={{ top: 2, bottom: 2 }}>
@@ -269,13 +276,6 @@ export default function WeeklySummaryCard({ children }) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <ProgressRing
-              value={todayDistanceKm}
-              max={DISTANCE_GOAL_KM}
-              unit="km"
-              title="Distance today"
-              size={60}
-            />
             {children}
           </div>
         )}


### PR DESCRIPTION
## Summary
- move `ProgressRing` to the start of the stats row
- keep spark lines and children after the progress ring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688911883c2c83249cfdd16e94a4ca65