### PR TITLE
Fix overlapping text in donut chart

### DIFF
--- a/frontend/src/components/DemoCharts/DemoCharts.jsx
+++ b/frontend/src/components/DemoCharts/DemoCharts.jsx
@@ -39,9 +39,6 @@ export default function DemoCharts() {
               <Tooltip formatter={(v, n) => [`${v}%`, n]} />
             </PieChart>
           </ResponsiveContainer>
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-            <span className="uppercase opacity-60">treadmill</span>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- clean up label layout in `DemoCharts` donut chart
- remove extraneous overlay text

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688911d2f42883248bf3875192a10883