### PR TITLE
Convert backend for Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Add the `VITE_BACKEND_URL` environment variable in the Vercel dashboard so the
 frontend knows where to reach your backend. Vercel will run `npm run build` and
 serve the generated static files from `frontend/dist`.
 
-The backend can be hosted separately on any platform that supports FastAPI.
+The backend can be hosted separately on any platform that supports FastAPI. For
+one‑repo deployments you may also place a FastAPI app inside the `api/` folder
+and include a `vercel.json` file that rewrites paths such as `/steps` or
+`/activities` to that serverless function.
 
 ## Frontend Features
 

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from backend.app.main import app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+python-dotenv
+requests
+requests-oauthlib
+pytest
+httpx

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "functions": {
+    "api/**/*.py": { "runtime": "python3.11" }
+  },
+  "rewrites": [
+    { "source": "/activities", "destination": "/api/index.py" },
+    { "source": "/activities/by-date", "destination": "/api/index.py" },
+    { "source": "/activities/:id", "destination": "/api/index.py" },
+    { "source": "/activities/:id/track", "destination": "/api/index.py" },
+    { "source": "/steps", "destination": "/api/index.py" },
+    { "source": "/heartrate", "destination": "/api/index.py" },
+    { "source": "/vo2max", "destination": "/api/index.py" },
+    { "source": "/sleep", "destination": "/api/index.py" },
+    { "source": "/map", "destination": "/api/index.py" },
+    { "source": "/routes", "destination": "/api/index.py" },
+    { "source": "/runs", "destination": "/api/index.py" },
+    { "source": "/daily-totals", "destination": "/api/index.py" },
+    { "source": "/analysis", "destination": "/api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add root `requirements.txt` for Vercel Python runtime
- expose FastAPI app as a serverless function in `api/index.py`
- add `vercel.json` rewrites for all backend routes
- document serverless option in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891b7fde908324848b6934bb9e0ff1