### PR TITLE
Add valueClassName option to ProgressRing

### DIFF
--- a/frontend/src/components/KPIGrid.jsx
+++ b/frontend/src/components/KPIGrid.jsx
@@ -78,13 +78,19 @@ export default function KPIGrid() {
         <div className="col-span-3 text-center text-sm font-normal text-destructive">{error}</div>
       )}
       {!loading && !error &&
-        items.map((item) => (
+        items.map((item, idx) => (
 
           <Card key={item.label} className="animate-in fade-in h-40">
 
             <CardContent className="flex flex-col items-center justify-center gap-2 h-full">
               {item.icon && <item.icon className="h-6 w-6" />}
-              <ProgressRing value={item.value} max={item.goal} unit={item.unit} size={80} />
+              <ProgressRing
+                value={item.value}
+                max={item.goal}
+                unit={item.unit}
+                size={80}
+                valueClassName={idx === 0 ? "text-xl" : undefined}
+              />
               <div className="text-sm font-medium text-muted-foreground text-center">{item.label}</div>
             </CardContent>
           </Card>

--- a/frontend/src/components/ui/ProgressRing.jsx
+++ b/frontend/src/components/ui/ProgressRing.jsx
@@ -8,6 +8,7 @@ export default function ProgressRing({
   unit = "",
   className = "",
   title = "",
+  valueClassName = "text-[2rem]",
 }) {
   const percent = Math.max(0, Math.min(1, value / max)) * 100;
   const data = [{ name: "progress", value: percent }];
@@ -48,7 +49,7 @@ export default function ProgressRing({
         </RadialBarChart>
       </ResponsiveContainer>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-[2rem] font-bold leading-none">{value}</span>
+        <span className={"font-bold leading-none " + valueClassName}>{value}</span>
         {unit && (
           <span className="text-xs text-muted-foreground">{unit}</span>
         )}

--- a/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
+++ b/frontend/src/components/ui/__tests__/ProgressRing.test.jsx
@@ -38,3 +38,11 @@ it('shows unit label when provided', () => {
   );
   expect(getByText('steps')).toBeInTheDocument();
 });
+
+it('applies custom value class name', () => {
+  const { getByText } = render(
+    <ProgressRing value={42} max={100} valueClassName="text-sm" />
+  );
+  const span = getByText('42');
+  expect(span.className).toContain('text-sm');
+});


### PR DESCRIPTION
## Summary
- allow customizing numeric text size in `ProgressRing`
- use smaller text for the first KPI in `KPIGrid`
- test new property

## Testing
- `pytest -q backend/tests/test_api.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892f2e8f408324b87c10c07d756d5c