### PR TITLE
docs: clean up README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,3 @@ and sparklines sit in the card content below.
 `frontend/src/components/SummaryCard.jsx` presents overall run statistics. It
 now includes a mini map for the most recent run and a small filled distance
 sparkline to visualize trends.
-
-help


### PR DESCRIPTION
## Summary
- remove stray footer text from the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889492b6b908324a8d4d3961defa747