### PR TITLE
feat(frontend): adopt shadcn table for state list

### DIFF
--- a/frontend/src/components/StatesTable.jsx
+++ b/frontend/src/components/StatesTable.jsx
@@ -1,43 +1,83 @@
 import { states } from "@/data/states";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "./ui/Table";
+import React from "react";
 
 export default function StatesTable() {
-  const visited = states.filter((s) => s.visited);
-  const mid = Math.ceil(visited.length / 2);
-  const left = visited.slice(0, mid);
-  const right = visited.slice(mid);
+  const [sortField, setSortField] = React.useState("miles");
+  const [sortDir, setSortDir] = React.useState("desc");
+
+  const visited = React.useMemo(() => states.filter((s) => s.visited), []);
+
+  const sorted = React.useMemo(() => {
+    const arr = [...visited];
+    arr.sort((a, b) => {
+      let cmp = 0;
+      if (sortField === "name") {
+        cmp = a.name.localeCompare(b.name);
+      } else {
+        cmp = a[sortField] - b[sortField];
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return arr;
+  }, [visited, sortField, sortDir]);
+
+  const mid = Math.ceil(sorted.length / 2);
+  const left = sorted.slice(0, mid);
+  const right = sorted.slice(mid);
+
+  const handleSort = (field) => {
+    setSortDir((dir) => (field === sortField ? (dir === "asc" ? "desc" : "asc") : "desc"));
+    setSortField(field);
+  };
+
+  const indicator = (field) => {
+    if (field !== sortField) return null;
+    return sortDir === "asc" ? "↑" : "↓";
+  };
 
   const renderRows = (list) =>
     list.map((s) => (
-      <tr key={s.abbr} className="group hover:bg-muted">
-        {/* use the default sans-serif font (Inter) for consistency */}
-        <td className="py-2 px-4 text-sm cursor-pointer">› {s.name}</td>
-        <td className="py-2 px-4 text-sm tabular-nums">{s.days}</td>
-        <td className="py-2 px-4 text-sm tabular-nums">{s.miles.toFixed(1)}</td>
-      </tr>
+      <TableRow key={s.abbr} className="group">
+        <TableCell className="cursor-pointer">› {s.name}</TableCell>
+        <TableCell className="tabular-nums">{s.days}</TableCell>
+        <TableCell className="tabular-nums">{s.miles.toFixed(1)}</TableCell>
+      </TableRow>
     ));
+
+  const renderTable = (list) => (
+    <Table className="text-left">
+      <TableHeader>
+        <TableRow>
+          <TableHead onClick={() => handleSort("name")}
+            className="cursor-pointer select-none">
+            STATE {indicator("name")}
+          </TableHead>
+          <TableHead onClick={() => handleSort("days")}
+            className="cursor-pointer select-none">
+            DAYS {indicator("days")}
+          </TableHead>
+          <TableHead onClick={() => handleSort("miles")}
+            className="cursor-pointer select-none">
+            MILES {indicator("miles")}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>{renderRows(list)}</TableBody>
+    </Table>
+  );
 
   return (
     <div className="grid grid-cols-2 gap-4">
-      <table className="w-full text-left">
-        <thead className="border-b">
-          <tr>
-            <th className="px-4 py-2">STATE</th>
-            <th className="px-4 py-2">DAYS</th>
-            <th className="px-4 py-2">↓ MILES</th>
-          </tr>
-        </thead>
-        <tbody>{renderRows(left)}</tbody>
-      </table>
-      <table className="w-full text-left">
-        <thead className="border-b">
-          <tr>
-            <th className="px-4 py-2">STATE</th>
-            <th className="px-4 py-2">DAYS</th>
-            <th className="px-4 py-2">↓ MILES</th>
-          </tr>
-        </thead>
-        <tbody>{renderRows(right)}</tbody>
-      </table>
+      {renderTable(left)}
+      {renderTable(right)}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/StatesTable.test.jsx
+++ b/frontend/src/components/__tests__/StatesTable.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StatesTable from '../StatesTable';
+
+function firstRow(container) {
+  return container.querySelector('tbody tr');
+}
+
+it('sorts by miles descending by default', () => {
+  const { container } = render(<StatesTable />);
+  expect(firstRow(container)).toHaveTextContent('Wisconsin');
+});
+
+it('sorts by days when header clicked', async () => {
+  const { container } = render(<StatesTable />);
+  await userEvent.click(screen.getAllByText('DAYS')[0]);
+  expect(firstRow(container)).toHaveTextContent('California');
+});
+
+it('toggles sort direction on repeated click', async () => {
+  const { container } = render(<StatesTable />);
+  const header = screen.getAllByText('DAYS')[0];
+  await userEvent.click(header); // desc
+  await userEvent.click(header); // asc
+  expect(firstRow(container)).toHaveTextContent('Delaware');
+});

--- a/frontend/src/components/ui/Table.jsx
+++ b/frontend/src/components/ui/Table.jsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <thead
+    ref={ref}
+    className={cn("sticky top-0 z-10 bg-background [&_tr]:border-b", className)}
+    {...props}
+  />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors odd:bg-muted/20 even:bg-background hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+};


### PR DESCRIPTION
## Summary
- implement `Table` component based on shadcn UI
- switch `StatesTable` to use new table with sorting ability
- add tests for sorting behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894b0806c48324823389434b497d2c