### PR TITLE
feat(frontend): include additional shadcn ui components

### DIFF
--- a/frontend/src/components/ui/Badge.jsx
+++ b/frontend/src/components/ui/Badge.jsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+const Badge = ({ className, variant, ...props }) => {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+};
+
+export { Badge, badgeVariants };

--- a/frontend/src/components/ui/Calendar.jsx
+++ b/frontend/src/components/ui/Calendar.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export function Calendar({ className = "", ...props }) {
+  return (
+    <input
+      type="date"
+      className={"rounded-md border px-3 py-2 " + className}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/Popover.jsx
+++ b/frontend/src/components/ui/Popover.jsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState } from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+const PopoverContext = createContext();
+
+export function Popover({ children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <PopoverContext.Provider value={{ open, setOpen }}>
+      <div className="relative inline-block">{children}</div>
+    </PopoverContext.Provider>
+  );
+}
+
+export const PopoverTrigger = React.forwardRef(
+  ({ asChild = false, ...props }, ref) => {
+    const { open, setOpen } = useContext(PopoverContext);
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        ref={ref}
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        {...props}
+      />
+    );
+  }
+);
+PopoverTrigger.displayName = "PopoverTrigger";
+
+export const PopoverContent = React.forwardRef(
+  ({ className = "", ...props }, ref) => {
+    const { open } = useContext(PopoverContext);
+    if (!open) return null;
+    return (
+      <div
+        ref={ref}
+        className={
+          "absolute z-50 mt-2 rounded-md border bg-popover p-4 text-popover-foreground shadow-md " +
+          className
+        }
+        {...props}
+      />
+    );
+  }
+);
+PopoverContent.displayName = "PopoverContent";

--- a/frontend/src/components/ui/Progress.jsx
+++ b/frontend/src/components/ui/Progress.jsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Progress = React.forwardRef(
+  ({ value = 0, max = 100, className = "", ...props }, ref) => {
+    const percent = Math.max(0, Math.min(100, (value / max) * 100));
+    return (
+      <div
+        ref={ref}
+        className={cn("h-2 w-full overflow-hidden rounded-full bg-secondary", className)}
+        {...props}
+      >
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: percent + "%" }}
+        />
+      </div>
+    );
+  }
+);
+Progress.displayName = "Progress";

--- a/frontend/src/components/ui/__tests__/Badge.test.jsx
+++ b/frontend/src/components/ui/__tests__/Badge.test.jsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import { Badge } from '../Badge';
+
+test('renders badge children', () => {
+  render(<Badge>Test</Badge>);
+  expect(screen.getByText('Test')).toBeInTheDocument();
+});

--- a/frontend/src/components/ui/__tests__/Calendar.test.jsx
+++ b/frontend/src/components/ui/__tests__/Calendar.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import { Calendar } from '../Calendar';
+
+test('renders input element', () => {
+  const { container } = render(<Calendar />);
+  expect(container.querySelector('input[type="date"]')).toBeInTheDocument();
+});

--- a/frontend/src/components/ui/__tests__/Popover.test.jsx
+++ b/frontend/src/components/ui/__tests__/Popover.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Popover, PopoverTrigger, PopoverContent } from '../Popover';
+
+test('shows content when trigger clicked', async () => {
+  render(
+    <Popover>
+      <PopoverTrigger>Open</PopoverTrigger>
+      <PopoverContent>Content</PopoverContent>
+    </Popover>
+  );
+  expect(screen.queryByText('Content')).not.toBeInTheDocument();
+  await userEvent.click(screen.getByText('Open'));
+  expect(screen.getByText('Content')).toBeInTheDocument();
+});

--- a/frontend/src/components/ui/__tests__/Progress.test.jsx
+++ b/frontend/src/components/ui/__tests__/Progress.test.jsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { Progress } from '../Progress';
+
+test('applies width style based on value', () => {
+  const { container } = render(<Progress value={50} max={100} />);
+  const bar = container.firstChild.firstChild;
+  expect(bar.getAttribute('style')).toContain('width: 50%');
+});


### PR DESCRIPTION
## Summary
- add Badge UI component
- add Popover UI component with trigger and content
- add simple Calendar date input
- add Progress bar component
- cover the new components with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68895fdeb44083248199f3d79fbe5f14