### PR TITLE
Switch shadcn base color to blue

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "tailwind.config.js",
     "css": "src/styles/globals.css",
-    "baseColor": "zinc",
+    "baseColor": "blue",
     "cssVariables": true,
     "prefix": ""
   },


### PR DESCRIPTION
## Summary
- use blue theme in shadcn config

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889648ec95083249fcacb5624074c0c