### PR TITLE
Add Input component and integrate into calendar

### DIFF
--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Card, CardHeader, CardContent } from "./ui/Card";
 import Skeleton from "./ui/Skeleton";
 import { fetchDailyTotals, fetchSteps, fetchSleep } from "../api";
+import { Input } from "@/components/ui/Input";
 import {
   LineChart,
   Line,
@@ -181,15 +182,13 @@ export default function WeeklySummaryCard({ children }) {
           </Select>
           {range === "custom" && (
             <>
-              <input
+              <Input
                 type="date"
-                className="rounded-md p-1 text-sm"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
               />
-              <input
+              <Input
                 type="date"
-                className="rounded-md p-1 text-sm"
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}
               />

--- a/frontend/src/components/ui/Calendar.jsx
+++ b/frontend/src/components/ui/Calendar.jsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { Input } from "./Input";
 
 export function Calendar({ className = "", ...props }) {
   return (
-    <input
+    <Input
       type="date"
-      className={"rounded-md border px-3 py-2 " + className}
+      className={className}
       {...props}
     />
   );

--- a/frontend/src/components/ui/Input.jsx
+++ b/frontend/src/components/ui/Input.jsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef(({ className = "", type = "text", ...props }, ref) => (
+  <input
+    ref={ref}
+    type={type}
+    className={cn(
+      "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+Input.displayName = "Input";
+export { Input };


### PR DESCRIPTION
## Summary
- add `Input` component based on shadcn
- use the new `Input` in `WeeklySummaryCard`
- update `Calendar` to render `Input`
- keep tests verifying the calendar renders a date input

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897d65f0b083248e7ef3c27a079230