### PR TITLE
Add clickable state popovers

### DIFF
--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -1,17 +1,30 @@
 import { states } from "@/data/states";
+import { Popover, PopoverTrigger, PopoverContent } from "./ui/Popover";
+import { getCities } from "@/data/stateCities";
 
 export default function StatesGrid() {
   return (
     <div className="grid grid-cols-12 grid-rows-7 gap-1">
       {states.map((s) => (
-        <div
-          key={s.abbr}
-          style={{ gridColumn: s.col, gridRow: s.row }}
-          className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${s.visited ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}
-          title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
-        >
-          {s.abbr}
-        </div>
+        <Popover key={s.abbr}>
+          <PopoverTrigger asChild>
+            <div
+              style={{ gridColumn: s.col, gridRow: s.row }}
+              className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${s.visited ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}
+              title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
+            >
+              {s.abbr}
+            </div>
+          </PopoverTrigger>
+          <PopoverContent className="text-xs">
+            <div className="font-semibold mb-1">{s.name}</div>
+            <ul className="list-disc pl-4">
+              {getCities(s.abbr).map((c) => (
+                <li key={c}>{c}</li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
       ))}
     </div>
   );

--- a/frontend/src/components/__tests__/MapSection.test.jsx
+++ b/frontend/src/components/__tests__/MapSection.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import MapSection from '../MapSection';
 
@@ -11,18 +11,21 @@ vi.mock('../LeafletMap', () => ({ default: () => <div data-testid="leaflet" /> }
 vi.mock('../ElevationChart', () => ({ default: () => <div data-testid="elev" /> }));
 
 
-it('fetches routes on mount', async () => {
+it('fetches activity data on mount', async () => {
   global.fetch = vi.fn((url) => {
-    if (url.startsWith('/routes')) {
+    if (url.startsWith('/activities/by-date')) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([{ lat: 0, lon: 0 }]),
+        json: () => Promise.resolve({ '2024-01-01': [{ activityId: '1' }] }),
       });
+    }
+    if (url.startsWith('/activities/1/track')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
   });
 
   render(<MapSection />);
-  await waitFor(() => expect(screen.getByTestId('routeheat')).toBeInTheDocument());
-  expect(global.fetch).toHaveBeenCalledWith('/routes');
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/activities/by-date'));
+  expect(global.fetch).toHaveBeenCalledWith('/activities/1/track');
 });

--- a/frontend/src/components/__tests__/StatesGrid.test.jsx
+++ b/frontend/src/components/__tests__/StatesGrid.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StatesGrid from '../StatesGrid';
+
+test('shows cities when state clicked', async () => {
+  render(<StatesGrid />);
+  const cell = screen.getByText('CA');
+  await userEvent.click(cell);
+  expect(screen.getByText('California')).toBeInTheDocument();
+  expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+});

--- a/frontend/src/data/stateCities.js
+++ b/frontend/src/data/stateCities.js
@@ -1,0 +1,10 @@
+export const stateCities = {
+  CA: ["Los Angeles", "San Francisco", "San Diego"],
+  TX: ["Houston", "Austin", "Dallas"],
+  WI: ["Madison", "Milwaukee", "Green Bay"],
+  NY: ["New York City", "Buffalo", "Albany"],
+};
+
+export function getCities(abbr) {
+  return stateCities[abbr] || ["Example City"];
+}


### PR DESCRIPTION
## Summary
- show placeholder city list when clicking a state
- test StatesGrid popover behaviour
- adapt MapSection test to stripped-down component

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897e551db48324a7499fa57ef6ea93