### PR TITLE
Add light/dark favicons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)">
+  <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)">
   <script>
     (function() {
       const ls = localStorage.theme;

--- a/frontend/public/favicon-dark.svg
+++ b/frontend/public/favicon-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="100%" height="100%" fill="#000000"/>
+  <text x="50%" y="50%" font-family="Inter, sans-serif" font-size="32" font-weight="700" fill="#ffffff" dominant-baseline="middle" text-anchor="middle">AJO</text>
+</svg>

--- a/frontend/public/favicon-light.svg
+++ b/frontend/public/favicon-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="50%" y="50%" font-family="Inter, sans-serif" font-size="32" font-weight="700" fill="#000000" dominant-baseline="middle" text-anchor="middle">AJO</text>
+</svg>


### PR DESCRIPTION
## Summary
- add two SVG favicon variants in the public folder
- reference `favicon-light.svg` and `favicon-dark.svg` in index.html for light/dark mode support

## Testing
- `npm run test` *(fails: MapSection.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68898093998c83249ad831477a291d99