### PR TITLE
Add expandable state details in US states table

### DIFF
--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -1,31 +1,29 @@
 import { states } from "@/data/states";
-import { Popover, PopoverTrigger, PopoverContent } from "./ui/Popover";
-import { getCities } from "@/data/stateCities";
 
-export default function StatesGrid() {
+/**
+ * Display grid of state abbreviations. Clicking a state
+ * triggers the `onSelect` callback with the abbreviation.
+ */
+export default function StatesGrid({ onSelect, selected }) {
   return (
     <div className="grid grid-cols-12 grid-rows-7 gap-1">
-      {states.map((s) => (
-        <Popover key={s.abbr}>
-          <PopoverTrigger asChild>
-            <div
-              style={{ gridColumn: s.col, gridRow: s.row }}
-              className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${s.visited ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}
-              title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
-            >
-              {s.abbr}
-            </div>
-          </PopoverTrigger>
-          <PopoverContent className="text-xs">
-            <div className="font-semibold mb-1">{s.name}</div>
-            <ul className="list-disc pl-4">
-              {getCities(s.abbr).map((c) => (
-                <li key={c}>{c}</li>
-              ))}
-            </ul>
-          </PopoverContent>
-        </Popover>
-      ))}
+      {states.map((s) => {
+        const visitedClass = s.visited
+          ? "bg-foreground text-background"
+          : "bg-muted text-muted-foreground";
+        const selectedClass = selected === s.abbr ? "ring-2 ring-primary" : "";
+        return (
+          <div
+            key={s.abbr}
+            style={{ gridColumn: s.col, gridRow: s.row }}
+            onClick={() => onSelect?.(s.abbr)}
+            className={`w-8 h-8 flex items-center justify-center text-xs font-semibold rounded-sm cursor-pointer ${visitedClass} ${selectedClass}`}
+            title={`${s.name}${s.visited ? ` – ${s.days} days, ${s.miles} mi` : ""}`}
+          >
+            {s.abbr}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/StatesTable.jsx
+++ b/frontend/src/components/StatesTable.jsx
@@ -1,4 +1,5 @@
 import { states } from "@/data/states";
+import { getCities } from "@/data/stateCities";
 import {
   Table,
   TableHeader,
@@ -9,7 +10,7 @@ import {
 } from "./ui/Table";
 import React from "react";
 
-export default function StatesTable() {
+export default function StatesTable({ selected }) {
   const [sortField, setSortField] = React.useState("miles");
   const [sortDir, setSortDir] = React.useState("desc");
 
@@ -45,11 +46,27 @@ export default function StatesTable() {
 
   const renderRows = (list) =>
     list.map((s) => (
-      <TableRow key={s.abbr} className="group">
-        <TableCell className="cursor-pointer">› {s.name}</TableCell>
-        <TableCell className="tabular-nums">{s.days}</TableCell>
-        <TableCell className="tabular-nums">{s.miles.toFixed(1)}</TableCell>
-      </TableRow>
+      <React.Fragment key={s.abbr}>
+        <TableRow
+          className="group"
+          data-state={s.abbr === selected ? "selected" : undefined}
+        >
+          <TableCell className="cursor-pointer">› {s.name}</TableCell>
+          <TableCell className="tabular-nums">{s.days}</TableCell>
+          <TableCell className="tabular-nums">{s.miles.toFixed(1)}</TableCell>
+        </TableRow>
+        {s.abbr === selected && (
+          <TableRow className="bg-muted/50">
+            <TableCell colSpan={3} className="p-2 pl-8">
+              <ul className="list-disc pl-4">
+                {getCities(s.abbr).map((c) => (
+                  <li key={c}>{c}</li>
+                ))}
+              </ul>
+            </TableCell>
+          </TableRow>
+        )}
+      </React.Fragment>
     ));
 
   const renderTable = (list) => (

--- a/frontend/src/components/StatesVisited.jsx
+++ b/frontend/src/components/StatesVisited.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { states } from "@/data/states";
 import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
 import StatesGrid from "./StatesGrid";
@@ -6,6 +7,7 @@ import StatesTable from "./StatesTable";
 
 export default function StatesVisited() {
   const visitedCount = states.filter((s) => s.visited).length;
+  const [selected, setSelected] = React.useState(null);
   return (
     <Card className="animate-in fade-in">
       <CardHeader className="text-center">
@@ -16,11 +18,11 @@ export default function StatesVisited() {
       </CardHeader>
       <CardContent className="lg:flex lg:gap-8">
         <div className="flex-shrink-0">
-          <StatesGrid />
+          <StatesGrid onSelect={setSelected} selected={selected} />
           <Legend />
         </div>
         <div className="flex-1 mt-6 lg:mt-0">
-          <StatesTable />
+          <StatesTable selected={selected} />
         </div>
       </CardContent>
     </Card>

--- a/frontend/src/components/__tests__/StatesGrid.test.jsx
+++ b/frontend/src/components/__tests__/StatesGrid.test.jsx
@@ -2,10 +2,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import StatesGrid from '../StatesGrid';
 
-test('shows cities when state clicked', async () => {
-  render(<StatesGrid />);
+test('calls onSelect when state clicked', async () => {
+  const onSelect = vi.fn();
+  render(<StatesGrid onSelect={onSelect} />);
   const cell = screen.getByText('CA');
   await userEvent.click(cell);
-  expect(screen.getByText('California')).toBeInTheDocument();
-  expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+  expect(onSelect).toHaveBeenCalledWith('CA');
 });

--- a/frontend/src/components/__tests__/StatesTable.test.jsx
+++ b/frontend/src/components/__tests__/StatesTable.test.jsx
@@ -24,3 +24,8 @@ it('toggles sort direction on repeated click', async () => {
   await userEvent.click(header); // asc
   expect(firstRow(container)).toHaveTextContent('Delaware');
 });
+
+it('shows cities when selected', () => {
+  render(<StatesTable selected="CA" />);
+  expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- track selected state in `StatesVisited`
- make `StatesGrid` notify selection
- expand rows in `StatesTable` to show cities when selected
- update corresponding unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898192a2d08324b8bd44ddff7c05fd