### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,13 @@
 import React from "react";
 import DashboardPage from "@/components/DashboardPage";
+import ModeToggle from "@/components/ModeToggle";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <div className="p-4 flex justify-end">
+        <ModeToggle />
+      </div>
       <main className="mx-auto max-w-[1200px]">
         <DashboardPage />
       </main>

--- a/frontend/src/components/ModeToggle.jsx
+++ b/frontend/src/components/ModeToggle.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "./ui/Button";
+
+export default function ModeToggle() {
+  const [isDark, setIsDark] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  function toggle() {
+    const root = document.documentElement;
+    const newDark = !root.classList.contains("dark");
+    root.classList.toggle("dark", newDark);
+    localStorage.theme = newDark ? "dark" : "light";
+    setIsDark(newDark);
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ModeToggle` component for switching themes
- show theme toggle in `App`

## Testing
- `npm test` in `frontend`
- `pytest` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6889826bfff0832482a67839670c1fbe