### PR TITLE
Add mileage rings widget

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -5,6 +5,7 @@ import WeatherChart from "./WeatherChart";
 import TemperatureChart from "./TemperatureChart";
 import StatesVisited from "./StatesVisited";
 import WeeklySummaryCard from "./WeeklySummaryCard";
+import MileageRings from "./MileageRings";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
 
@@ -15,6 +16,8 @@ export default function DashboardPage() {
       <h2 className="text-sm font-medium text-muted-foreground mb-2">Activity Overview</h2>
 
       <WeeklySummaryCard />
+
+      <MileageRings />
 
       <React.Suspense
         fallback={

--- a/frontend/src/components/MileageRings.jsx
+++ b/frontend/src/components/MileageRings.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { parseISO, startOfWeek, format } from "date-fns";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
+import ProgressRing from "./ui/ProgressRing";
+import Skeleton from "./ui/Skeleton";
+import { fetchDailyTotals } from "../api";
+import { Check } from "lucide-react";
+
+const DEFAULT_GOAL_KM = 40;
+
+function groupByWeek(totals) {
+  const weeks = {};
+  for (const { date, distance } of totals) {
+    const weekStart = format(
+      startOfWeek(parseISO(date), { weekStartsOn: 1 }),
+      "yyyy-MM-dd"
+    );
+    weeks[weekStart] = (weeks[weekStart] || 0) + distance;
+  }
+  return Object.entries(weeks)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([weekStart, dist]) => ({ weekStart, distanceKm: dist / 1000 }));
+}
+
+export default function MileageRings({ goalKm = DEFAULT_GOAL_KM, weeksToShow = 4 }) {
+  const [weeks, setWeeks] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchDailyTotals()
+      .then((rows) => {
+        const grouped = groupByWeek(rows).slice(-weeksToShow);
+        setWeeks(grouped);
+      })
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, [weeksToShow]);
+
+  return (
+    <Card className="animate-in fade-in">
+      <CardHeader>
+        <CardTitle>Mileage Rings</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-wrap justify-center gap-4">
+        {loading && <Skeleton className="h-20 w-20 rounded-full" />}
+        {error && !loading && (
+          <div className="text-sm text-destructive">{error}</div>
+        )}
+        {!loading && !error &&
+          weeks.map(({ weekStart, distanceKm }) => (
+            <div key={weekStart} className="flex flex-col items-center">
+              <div className="relative">
+                <ProgressRing
+                  value={Math.round(distanceKm)}
+                  max={goalKm}
+                  unit="km"
+                  size={80}
+                  title={`Week of ${weekStart}`}
+                />
+                {distanceKm >= goalKm && (
+                  <Check className="absolute inset-0 m-auto h-6 w-6 text-emerald-600 z-10 animate-in fade-in pointer-events-none" />
+                )}
+              </div>
+              <span className="mt-1 text-xs text-muted-foreground">
+                {format(parseISO(weekStart), "MMM d")}
+              </span>
+            </div>
+          ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/__tests__/MileageRings.test.jsx
+++ b/frontend/src/components/__tests__/MileageRings.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import MileageRings from '../MileageRings';
+import { vi } from 'vitest';
+
+afterEach(() => vi.restoreAllMocks());
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() { this.cb([{ contentRect: { width: 80, height: 80 } }]); }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 80,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 80,
+  });
+});
+
+function makeTotals(dist) {
+  const totals = [];
+  const start = new Date('2023-01-01');
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(start.getTime() + i * 86400000);
+    totals.push({ date: d.toISOString().split('T')[0], distance: dist, duration: 0 });
+  }
+  return totals;
+}
+
+it('renders rings grouped by week', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(makeTotals(5000)),
+  });
+
+  render(<MileageRings goalKm={40} weeksToShow={1} />);
+  const ring = await screen.findByTitle(/Week of/);
+  expect(ring).toBeInTheDocument();
+  expect(global.fetch).toHaveBeenCalledWith('/daily-totals');
+});
+
+it('shows check icon when goal met', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(makeTotals(10000)),
+  });
+
+  const { container } = render(<MileageRings goalKm={50} weeksToShow={1} />);
+  await screen.findByTitle(/Week of/);
+  const icon = container.querySelector('svg.lucide-check');
+  expect(icon).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show mileage rings summarizing weekly distance
- animate a check icon when goal is met
- display mileage rings on the dashboard
- test mileage ring behavior

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68898338643083249ca80a0b2277c5aa