### PR TITLE
Add route gallery carousel

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "d3-array": "^3.2.4",
         "date-fns": "^3.6.0",
+        "embla-carousel-react": "^8.0.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.532.0",
         "react": "^18.2.0",
@@ -3156,6 +3157,34 @@
       "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "date-fns": "^3.6.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.532.0",
+    "embla-carousel-react": "^8.0.0",
     "react": "^18.2.0",
     "react-calendar-heatmap": "1.9.0",
     "react-chartjs-2": "^5.3.0",

--- a/frontend/src/components/MapSection.jsx
+++ b/frontend/src/components/MapSection.jsx
@@ -15,6 +15,7 @@ import {
 } from "../api";
 import ElevationChart from "./ElevationChart";
 const LazyMap = React.lazy(() => import("./LeafletMap"));
+const RouteGallery = React.lazy(() => import("./RouteGallery"));
 
 export default function MapSection() {
   const [points, setPoints] = React.useState([]);
@@ -51,10 +52,50 @@ export default function MapSection() {
   }, [loadTrack]);
 
 
-
   return (
     <div className="space-y-6">
-
+      <ChartCard title="Route Map">
+        <div className="h-64">
+          <React.Suspense fallback={<div className="h-full w-full bg-muted" />}> 
+            <LazyMap
+              points={points}
+              metricKey={metric}
+              showWeather={showWeather}
+              onHoverPoint={setHoverIdx}
+            />
+          </React.Suspense>
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <Select value={metric} onValueChange={setMetric}>
+            <SelectTrigger className="w-32 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="heartRate">Heart Rate</SelectItem>
+              <SelectItem value="speed">Speed</SelectItem>
+              <SelectItem value="elevation">Elevation</SelectItem>
+            </SelectContent>
+          </Select>
+          <label className="ml-auto flex items-center gap-1 text-xs">
+            <input
+              type="checkbox"
+              checked={showWeather}
+              onChange={(e) => setShowWeather(e.target.checked)}
+            />
+            Weather
+          </label>
+        </div>
+        <ElevationChart points={points} activeIndex={hoverIdx} />
+      </ChartCard>
+      <React.Suspense
+        fallback={
+          <div className="h-40 flex items-center justify-center text-sm font-normal text-muted-foreground">
+            Loading routes...
+          </div>
+        }
+      >
+        <RouteGallery />
+      </React.Suspense>
     </div>
   );
 }

--- a/frontend/src/components/RouteGallery.jsx
+++ b/frontend/src/components/RouteGallery.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import ChartCard from "./ChartCard";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "./ui/Carousel";
+import Skeleton from "./ui/Skeleton";
+import { fetchActivities, fetchActivityTrack } from "../api";
+const LazyMap = React.lazy(() => import("./LeafletMap"));
+
+export default function RouteGallery() {
+  const [routes, setRoutes] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchActivities({ limit: 5 })
+      .then(async (acts) => {
+        const withTracks = await Promise.all(
+          acts.map(async (act) => {
+            try {
+              const pts = await fetchActivityTrack(act.activityId);
+              return { id: act.activityId, distance: act.distance, points: pts };
+            } catch (_) {
+              return { id: act.activityId, distance: act.distance, points: [] };
+            }
+          })
+        );
+        setRoutes(withTracks);
+      })
+      .catch(() => setError("Failed to load routes"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <ChartCard title="Route Gallery">
+        <Skeleton className="h-40 w-full" />
+      </ChartCard>
+    );
+  }
+  if (error) {
+    return (
+      <ChartCard title="Route Gallery">
+        <div className="text-sm font-normal text-destructive">{error}</div>
+      </ChartCard>
+    );
+  }
+  if (!routes.length) {
+    return (
+      <ChartCard title="Route Gallery">
+        <div className="text-sm font-normal text-muted-foreground">No routes</div>
+      </ChartCard>
+    );
+  }
+
+  return (
+    <ChartCard title="Route Gallery">
+      <Carousel className="w-full">
+        <CarouselContent>
+          {routes.map((r) => (
+            <CarouselItem key={r.id} className="relative">
+              <div className="h-40 overflow-hidden rounded-md">
+                <React.Suspense fallback={<div className="h-full w-full bg-muted" />}>
+                  <LazyMap points={r.points} />
+                </React.Suspense>
+              </div>
+              <div className="absolute bottom-2 left-2 rounded bg-background/80 px-2 py-0.5 text-xs shadow">
+                {(r.distance / 1000).toFixed(1)} km
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/__tests__/MapSection.test.jsx
+++ b/frontend/src/components/__tests__/MapSection.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../ActivityCalendar', () => ({ default: () => <div data-testid="calenda
 vi.mock('../CalendarHeatmap', () => ({ default: () => <div data-testid="heatmap" /> }));
 vi.mock('../LeafletMap', () => ({ default: () => <div data-testid="leaflet" /> }));
 vi.mock('../ElevationChart', () => ({ default: () => <div data-testid="elev" /> }));
+vi.mock('../RouteGallery', () => ({ default: () => <div data-testid="gallery" /> }));
 
 
 it('fetches activity data on mount', async () => {

--- a/frontend/src/components/ui/Carousel.jsx
+++ b/frontend/src/components/ui/Carousel.jsx
@@ -1,0 +1,207 @@
+"use client";
+import * as React from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "./Button";
+
+const CarouselContext = React.createContext(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+  return context;
+}
+
+const Carousel = React.forwardRef(function Carousel(
+  {
+    orientation = "horizontal",
+    opts,
+    setApi,
+    plugins,
+    className = "",
+    children,
+    ...props
+  },
+  ref
+) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+  const onSelect = React.useCallback((api) => {
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = React.useCallback(
+    (event) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrev, scrollNext]
+  );
+
+  React.useEffect(() => {
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
+
+  React.useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
+    return () => api.off("select", onSelect);
+  }, [api, onSelect]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api,
+        opts,
+        orientation: orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        ref={ref}
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+});
+Carousel.displayName = "Carousel";
+
+const CarouselContent = React.forwardRef(function CarouselContent(
+  { className = "", ...props },
+  ref
+) {
+  const { carouselRef, orientation } = useCarousel();
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = React.forwardRef(function CarouselItem(
+  { className = "", ...props },
+  ref
+) {
+  const { orientation } = useCarousel();
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = "CarouselItem";
+
+const CarouselPrevious = React.forwardRef(function CarouselPrevious(
+  { className = "", variant = "outline", size = "icon", ...props },
+  ref
+) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
+
+const CarouselNext = React.forwardRef(function CarouselNext(
+  { className = "", variant = "outline", size = "icon", ...props },
+  ref
+) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = "CarouselNext";
+
+export { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext };


### PR DESCRIPTION
## Summary
- add `embla-carousel-react` dependency
- implement ShadCN Carousel UI component
- create `RouteGallery` with carousel of route maps
- display carousel in `MapSection`
- update tests for new component

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898326931483248f0d605977c77850