### PR TITLE
Use arrow bullets for state cities

### DIFF
--- a/frontend/src/components/StatesTable.jsx
+++ b/frontend/src/components/StatesTable.jsx
@@ -58,9 +58,12 @@ export default function StatesTable({ selected }) {
         {s.abbr === selected && (
           <TableRow className="bg-muted/50">
             <TableCell colSpan={3} className="p-2 pl-8">
-              <ul className="list-disc pl-4">
+              <ul className="space-y-1">
                 {getCities(s.abbr).map((c) => (
-                  <li key={c}>{c}</li>
+                  <li key={c} className="flex items-center gap-1">
+                    <span>›</span>
+                    <span>{c}</span>
+                  </li>
                 ))}
               </ul>
             </TableCell>


### PR DESCRIPTION
## Summary
- tweak StatesTable city dropdown styling to use arrow bullets

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688984f24d608324b8bdea0e889def20