### PR TITLE
Add playful what-if chart with sliders

### DIFF
--- a/frontend/src/components/AnalysisSection.jsx
+++ b/frontend/src/components/AnalysisSection.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import DemoCharts from "./DemoCharts/DemoCharts";
+import WhatIfScenarios from "./WhatIfScenarios";
 
 export default function AnalysisSection() {
   return (
     <div className="space-y-10">
       <DemoCharts />
+      <WhatIfScenarios />
     </div>
   );
 }

--- a/frontend/src/components/WhatIfScenarios.jsx
+++ b/frontend/src/components/WhatIfScenarios.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
+
+export function makeData(sleep, temp) {
+  const base = 6 - 0.1 * (sleep - 7) + 0.02 * (temp - 20);
+  const data = [];
+  for (let i = 1; i <= 7; i++) {
+    const pace = +(base + (i - 4) * 0.01).toFixed(2);
+    data.push({ day: i, pace });
+  }
+  return data;
+}
+
+export default function WhatIfScenarios() {
+  const [sleep, setSleep] = React.useState(7);
+  const [temp, setTemp] = React.useState(20);
+  const data = React.useMemo(() => makeData(sleep, temp), [sleep, temp]);
+
+  return (
+    <Card className="animate-in fade-in">
+      <CardHeader>
+        <CardTitle>What If?</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <label className="flex-1 text-sm">
+            Sleep: {sleep}h
+            <input
+              data-testid="sleep-slider"
+              type="range"
+              min="4"
+              max="10"
+              step="0.5"
+              value={sleep}
+              onChange={(e) => setSleep(parseFloat(e.target.value))}
+              className="w-full"
+            />
+          </label>
+          <label className="flex-1 text-sm">
+            Temp: {temp}°C
+            <input
+              data-testid="temp-slider"
+              type="range"
+              min="0"
+              max="40"
+              step="1"
+              value={temp}
+              onChange={(e) => setTemp(parseFloat(e.target.value))}
+              className="w-full"
+            />
+          </label>
+        </div>
+        <div className="h-48">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <XAxis dataKey="day" stroke="hsl(var(--muted-foreground))" />
+              <YAxis unit="min/km" stroke="hsl(var(--muted-foreground))" />
+              <Tooltip formatter={(v) => [`${v} min/km`, 'pace']} />
+              <Line type="monotone" dataKey="pace" stroke="hsl(var(--primary))" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/__tests__/WhatIfScenarios.test.jsx
+++ b/frontend/src/components/__tests__/WhatIfScenarios.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import WhatIfScenarios, { makeData } from '../WhatIfScenarios';
+import { vi } from 'vitest';
+
+afterEach(() => vi.restoreAllMocks());
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 100, height: 80 } }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+test('makeData produces 7 days of pace data', () => {
+  const data = makeData(8, 25);
+  expect(data).toHaveLength(7);
+  // first day pace slightly lower due to deterministic offset
+  expect(data[0].pace).toBeCloseTo(5.97);
+});
+
+test('sliders update displayed values', () => {
+  const { container } = render(<WhatIfScenarios />);
+  const sleepSlider = screen.getByTestId('sleep-slider');
+  fireEvent.change(sleepSlider, { target: { value: '9' } });
+  expect(screen.getByText(/Sleep: 9/)).toBeInTheDocument();
+  expect(container.querySelector('svg')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add WhatIfScenarios component with sliders for sleep and temperature
- integrate WhatIfScenarios into AnalysisSection
- test new component

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889842ac4c08324bc6c4d8f5ec62a79