### PR TITLE
Add activity calendar documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ activity type or date range to explore your workouts.
 
 The "Mileage" tab visualizes your cumulative distance per month in a line chart.
 
+The Activity Calendar displays a mini heatmap with one square per day. Days with
+runs or recorded steps are colored by their total distance so busier days appear
+darker.
+
 ## Tailwind Theme Setup
 
 The `src/main.jsx` entry point imports `@/index.css` which includes `tailwindcss-shadcn-ui/style.css` so shadcn/ui component styles are loaded. The interface uses icons from the **Lucide** set via the `lucide-react` package.


### PR DESCRIPTION
## Summary
- note Activity Calendar mini heatmap in README

## Testing
- `pytest -q backend/tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889834b536083248b1051c5dcf95b87