### PR TITLE
Fix missing MileageRings import

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -7,6 +7,7 @@ import StatesVisited from "./StatesVisited";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 
 import StreakFlame from "./StreakFlame";
+import MileageRings from "./MileageRings";
 
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));


### PR DESCRIPTION
## Summary
- import `MileageRings` in `DashboardPage`

## Testing
- `npm test --silent` in `frontend`
- `pytest -q` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68898925c23483248e7f013e3c7228c7