### PR TITLE
Fix duplicate imports on dashboard

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -7,15 +7,12 @@ import TemperatureChart from "./TemperatureChart";
 import StatesVisited from "./StatesVisited";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 import FitnessScoreDial from "./FitnessScoreDial";
+import StreakFlame from "./StreakFlame";
+import MileageRings from "./MileageRings";
+import TimeCapsule from "./TimeCapsule";
 const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
-
-
-  import StatesVisited from "./StatesVisited";
-  import WeeklySummaryCard from "./WeeklySummaryCard";
-  const MapSection = React.lazy(() => import("./MapSection"));
-  const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
-  const VirtualPathMap = React.lazy(() => import("./VirtualPathMap"));
+const VirtualPathMap = React.lazy(() => import("./VirtualPathMap"));
 
 
 export default function DashboardPage() {


### PR DESCRIPTION
## Summary
- deduplicate imports in `DashboardPage.jsx`
- add missing component imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68898c21e60c83248c2c9baab9939481