### PR TITLE
Remove mileage rings, distance ring, and maps

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -8,9 +8,7 @@ import StatesVisited from "./StatesVisited";
 import WeeklySummaryCard from "./WeeklySummaryCard";
 import FitnessScoreDial from "./FitnessScoreDial";
 import StreakFlame from "./StreakFlame";
-import MileageRings from "./MileageRings";
 import TimeCapsule from "./TimeCapsule";
-const MapSection = React.lazy(() => import("./MapSection"));
 const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
 const VirtualPathMap = React.lazy(() => import("./VirtualPathMap"));
 
@@ -24,8 +22,6 @@ export default function DashboardPage() {
       <WeeklySummaryCard>
         <StreakFlame />
       </WeeklySummaryCard>
-
-      <MileageRings />
 
       <React.Suspense
         fallback={
@@ -44,15 +40,6 @@ export default function DashboardPage() {
       <StatesVisited />
       <Card className="animate-in fade-in">
         <CardContent className="space-y-6">
-          <React.Suspense
-            fallback={
-              <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
-                Loading map...
-              </div>
-            }
-          >
-            <MapSection />
-          </React.Suspense>
           <KPIGrid />
 
           <FitnessScoreDial />

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -9,7 +9,6 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Download, Share2, ArrowUpRight, ArrowDownRight } from "lucide-react";
-import ProgressRing from "./ui/ProgressRing";
 import {
   Select,
   SelectTrigger,
@@ -18,8 +17,6 @@ import {
   SelectItem,
 } from "./ui/select";
 
-const STEP_GOAL = 10000;
-const DISTANCE_GOAL_KM = 20;
 
 export function computeStats(currSteps = [], prevSteps = [], currSleep = [], prevSleep = [], currTotals = [], prevTotals = []) {
   const sum = (arr, key) => arr.reduce((s, p) => s + (p[key] || 0), 0);
@@ -54,8 +51,6 @@ export default function WeeklySummaryCard({ children }) {
   const [startDate, setStartDate] = React.useState("");
   const [endDate, setEndDate] = React.useState("");
 
-  const todayDistanceKm =
-    (totals[totals.length - 1]?.distance ?? 0) / 1000;
 
   React.useEffect(() => {
     Promise.all([fetchSteps(), fetchSleep(), fetchDailyTotals()])
@@ -276,13 +271,6 @@ export default function WeeklySummaryCard({ children }) {
                 </LineChart>
               </ResponsiveContainer>
             </div>
-            <ProgressRing
-              value={todayDistanceKm}
-              max={DISTANCE_GOAL_KM}
-              unit="km"
-              title="Distance today"
-              size={60}
-            />
             {children}
           </div>
         )}


### PR DESCRIPTION
## Summary
- drop `MileageRings` section from the dashboard
- remove route map section on the dashboard
- delete `Distance today` progress ring from the weekly summary

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889927aeb78832496c8899f900842e2