### PR TITLE
Apply blue theme across charts

### DIFF
--- a/frontend/src/components/DemoWeatherCharts.jsx
+++ b/frontend/src/components/DemoWeatherCharts.jsx
@@ -42,21 +42,21 @@ export default function DemoWeatherCharts() {
                         y={y + 4}
                         textAnchor="end"
                         fontSize={12}
-                        fill="#334155"
+                        fill="hsl(var(--primary))"
                       >
                         {payload.value}
-                        <tspan fill="#64748B">  {range}</tspan>
+                        <tspan fill="hsl(var(--primary))">  {range}</tspan>
                       </text>
                     );
                   }}
                 />
               <Tooltip
                 formatter={(val) => [`${val} runs`, ""]}
-                cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}
+                cursor={{ fill: "hsl(var(--primary) / 0.1)" }}
               />
               <Bar
                 dataKey="count"
-                fill="#94A3B8"
+                fill="hsl(var(--primary))"
                 barSize={20}
                 radius={[4, 4, 4, 4]}
               />
@@ -90,9 +90,9 @@ export default function DemoWeatherCharts() {
                     return (
                       <g transform={`translate(${x - 40},${y - 10})`}>
                         {Icon && (
-                          <Icon size={16} fill="none" stroke="#334155" />
+                          <Icon size={16} fill="none" stroke="hsl(var(--primary))" />
                         )}
-                        <text x={24} y={16} fontSize={12} fill="#334155">
+                        <text x={24} y={16} fontSize={12} fill="hsl(var(--primary))">
                           {payload.value}
                         </text>
                       </g>
@@ -101,11 +101,11 @@ export default function DemoWeatherCharts() {
                 />
               <Tooltip
                 formatter={(val) => [`${val} runs`, ""]}
-                cursor={{ fill: "rgba(56, 189, 248, 0.1)" }}
+                cursor={{ fill: "hsl(var(--primary) / 0.1)" }}
               />
               <Bar
                 dataKey="count"
-                fill="#CBD5E1"
+                fill="hsl(var(--primary))"
                 barSize={20}
                 radius={[4, 4, 4, 4]}
               />

--- a/frontend/src/components/Legend.jsx
+++ b/frontend/src/components/Legend.jsx
@@ -10,7 +10,7 @@ export default function Legend() {
         <span>Not visited ({notVisited})</span>
       </div>
       <div className="flex items-center gap-1">
-        <span className="w-4 h-4 bg-foreground rounded-sm"></span>
+        <span className="w-4 h-4 bg-primary rounded-sm"></span>
         <span>Visited ({visited})</span>
       </div>
     </div>

--- a/frontend/src/components/StatesGrid.jsx
+++ b/frontend/src/components/StatesGrid.jsx
@@ -9,7 +9,7 @@ export default function StatesGrid({ onSelect, selected }) {
     <div className="grid grid-cols-12 grid-rows-7 gap-1">
       {states.map((s) => {
         const visitedClass = s.visited
-          ? "bg-foreground text-background"
+          ? "bg-primary text-primary-foreground"
           : "bg-muted text-muted-foreground";
         const selectedClass = selected === s.abbr ? "ring-2 ring-primary" : "";
         return (

--- a/frontend/src/components/TemperatureChart.jsx
+++ b/frontend/src/components/TemperatureChart.jsx
@@ -39,21 +39,21 @@ export default function TemperatureChart() {
                     y={y + 4}
                     textAnchor="end"
                     fontSize={12}
-                    fill="#334155"
+                    fill="hsl(var(--primary))"
                   >
                     {payload.value}
-                    <tspan fill="#64748B">  {range}</tspan>
+                    <tspan fill="hsl(var(--primary))">  {range}</tspan>
                   </text>
                 );
               }}
             />
             <Tooltip
               formatter={val => [`${val} runs`, ""]}
-              cursor={{ fill: "rgba(156, 163, 175, 0.1)" }}
+              cursor={{ fill: "hsl(var(--primary) / 0.1)" }}
             />
             <Bar
               dataKey="count"
-              fill="#111827"
+              fill="hsl(var(--primary))"
               barSize={20}
               radius={[4, 4, 4, 4]}
             />

--- a/frontend/src/components/WeatherChart.jsx
+++ b/frontend/src/components/WeatherChart.jsx
@@ -32,8 +32,8 @@ export default function WeatherChart() {
                 const Icon = entry ? entry.icon : null;
                 return (
                   <g transform={`translate(${x - 90},${y - 8})`}>
-                    {Icon && <Icon size={16} stroke="#64748B" />}
-                    <text x={24} y={12} fill="#334155" fontSize={12}>
+                    {Icon && <Icon size={16} stroke="hsl(var(--primary))" />}
+                    <text x={24} y={12} fill="hsl(var(--primary))" fontSize={12}>
                       {payload.value}
                     </text>
                   </g>
@@ -42,9 +42,9 @@ export default function WeatherChart() {
             />
             <Tooltip
               formatter={value => [`${value} runs`]}
-              cursor={{ fill: "rgba(156, 163, 175, 0.1)" }}
+              cursor={{ fill: "hsl(var(--primary) / 0.1)" }}
             />
-            <Bar dataKey="count" fill="#CBD5E1" barSize={20} radius={[4, 4, 4, 4]} />
+            <Bar dataKey="count" fill="hsl(var(--primary))" barSize={20} radius={[4, 4, 4, 4]} />
           </BarChart>
         </ResponsiveContainer>
       </CardContent>


### PR DESCRIPTION
## Summary
- update TemperatureChart to use primary color
- update WeatherChart to use primary color
- switch visited states and legend to blue
- adjust demo weather charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688993191450832494e6b1f45eca6611