### PR TITLE
Add date range filtering for analysis endpoint

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -112,11 +112,15 @@ def test_runs_endpoint():
 
 
 def test_analysis_endpoint():
-    resp = client.get('/analysis')
+    from app.main import dummy_activities
+
+    date = dummy_activities[0]['startTimeLocal'].split('T')[0]
+    resp = client.get(f'/analysis?start={date}&end={date}')
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)
     assert data
+    assert len(data) == 1
     first = data[0]
     assert 'avgPace' in first and 'temperature' in first
     assert 'distance' in first and 'avgHeartRate' in first

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,7 +20,10 @@ export const fetchActivityTrack = (id) => apiGet(`/activities/${id}/track`);
 export const fetchActivitiesByDate = () => apiGet('/activities/by-date');
 export const fetchDailyTotals = () => apiGet('/daily-totals');
 export const fetchRuns = () => apiGet('/runs');
-export const fetchAnalysis = () => apiGet('/analysis');
+export const fetchAnalysis = (params = {}) => {
+  const qs = new URLSearchParams(params).toString();
+  return apiGet(`/analysis${qs ? `?${qs}` : ''}`);
+};
 export const fetchActivities = (params = {}) => {
   const qs = new URLSearchParams(params).toString();
   return apiGet(`/activities${qs ? `?${qs}` : ''}`);

--- a/frontend/src/components/WeatherImpactBubbleChart.jsx
+++ b/frontend/src/components/WeatherImpactBubbleChart.jsx
@@ -13,13 +13,16 @@ import {
 } from "recharts";
 import { fetchAnalysis } from "../api";
 
-export default function WeatherImpactBubbleChart() {
+export default function WeatherImpactBubbleChart({ start, end } = {}) {
   const [data, setData] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
 
   React.useEffect(() => {
-    fetchAnalysis()
+    const params = {};
+    if (start) params.start = start;
+    if (end) params.end = end;
+    fetchAnalysis(params)
       .then((rows) => {
         const pts = rows.map((r) => ({
           temperature: r.temperature,
@@ -30,7 +33,7 @@ export default function WeatherImpactBubbleChart() {
       })
       .catch(() => setError("Failed to load"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [start, end]);
 
   const renderTooltip = (val, name) => {
     if (name === "distanceKm") return [`${val.toFixed(1)} km`, "Distance"];

--- a/frontend/src/components/__tests__/WeatherImpactBubbleChart.test.jsx
+++ b/frontend/src/components/__tests__/WeatherImpactBubbleChart.test.jsx
@@ -25,7 +25,7 @@ beforeAll(() => {
   });
 });
 
-test('renders scatter bubbles based on analysis data', async () => {
+test('renders scatter bubbles based on analysis data and passes dates', async () => {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: () =>
@@ -34,9 +34,16 @@ test('renders scatter bubbles based on analysis data', async () => {
       ]),
   });
 
-  const { container } = render(<WeatherImpactBubbleChart />);
+  const start = '2023-01-01';
+  const end = '2023-01-31';
+  const { container } = render(
+    <WeatherImpactBubbleChart start={start} end={end} />
+  );
   await waitFor(() => {
     const symbols = container.querySelectorAll('path.recharts-symbols');
     expect(symbols.length).toBeGreaterThan(0);
   });
+  expect(global.fetch).toHaveBeenCalledWith(
+    `/analysis?start=${start}&end=${end}`
+  );
 });

--- a/frontend/src/components/__tests__/api.test.js
+++ b/frontend/src/components/__tests__/api.test.js
@@ -1,4 +1,4 @@
-import { fetchRuns, fetchActivities } from '../../api';
+import { fetchRuns, fetchActivities, fetchAnalysis } from '../../api';
 import { vi } from 'vitest';
 
 afterEach(() => vi.restoreAllMocks());
@@ -24,4 +24,16 @@ test('fetchActivities adds query string with leading ? when params provided', as
 
   await fetchActivities({ type: 'run' });
   expect(global.fetch).toHaveBeenCalledWith('/activities?type=run');
+});
+
+test('fetchAnalysis adds query string when params provided', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve([]),
+  });
+
+  await fetchAnalysis({ start: '2023-01-01', end: '2023-02-01' });
+  expect(global.fetch).toHaveBeenCalledWith(
+    '/analysis?start=2023-01-01&end=2023-02-01'
+  );
 });


### PR DESCRIPTION
## Summary
- support `start` and `end` dates in backend `/analysis` endpoint
- allow optional query params in `fetchAnalysis` API helper
- refresh WeatherImpactBubbleChart when date range changes
- update frontend and backend tests for new parameters

## Testing
- `pytest -q`
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688994cde6bc8324ae1084038baf4805