### PR TITLE
Adjust chart text colors for dark mode

### DIFF
--- a/frontend/src/components/TemperatureChart.jsx
+++ b/frontend/src/components/TemperatureChart.jsx
@@ -39,10 +39,10 @@ export default function TemperatureChart() {
                     y={y + 4}
                     textAnchor="end"
                     fontSize={12}
-                    fill="hsl(var(--primary))"
+                    fill="currentColor"
                   >
                     {payload.value}
-                    <tspan fill="hsl(var(--primary))">  {range}</tspan>
+                    <tspan fill="currentColor">  {range}</tspan>
                   </text>
                 );
               }}

--- a/frontend/src/components/WeatherChart.jsx
+++ b/frontend/src/components/WeatherChart.jsx
@@ -32,8 +32,8 @@ export default function WeatherChart() {
                 const Icon = entry ? entry.icon : null;
                 return (
                   <g transform={`translate(${x - 90},${y - 8})`}>
-                    {Icon && <Icon size={16} stroke="hsl(var(--primary))" />}
-                    <text x={24} y={12} fill="hsl(var(--primary))" fontSize={12}>
+                    {Icon && <Icon size={16} stroke="currentColor" />}
+                    <text x={24} y={12} fill="currentColor" fontSize={12}>
                       {payload.value}
                     </text>
                   </g>


### PR DESCRIPTION
## Summary
- ensure icon and label colors in `WeatherChart` adapt to current theme
- make temperature chart labels use theme color instead of primary

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688997848a108324a8bf121ef3f8d247