### PR TITLE
Improve day/night split chart

### DIFF
--- a/frontend/src/components/DayNightLegend.jsx
+++ b/frontend/src/components/DayNightLegend.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export default function DayNightLegend({ dayMiles, nightMiles, totalMiles, colors = [] }) {
+  const dayColor = colors[0] || 'hsl(var(--accent))';
+  const nightColor = colors[1] || 'hsl(var(--primary))';
+  const dayPct = totalMiles ? (dayMiles / totalMiles) * 100 : 0;
+  const nightPct = totalMiles ? (nightMiles / totalMiles) * 100 : 0;
+  return (
+    <div className="flex items-center gap-4 mt-4 text-sm">
+      <div className="flex items-center gap-1">
+        <span className="w-4 h-4 rounded-sm" style={{ backgroundColor: dayColor }}></span>
+        <span>Day ({dayPct.toFixed(0)}%, {dayMiles.toFixed(1)} mi)</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="w-4 h-4 rounded-sm" style={{ backgroundColor: nightColor }}></span>
+        <span>Night ({nightPct.toFixed(0)}%, {nightMiles.toFixed(1)} mi)</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/DayNightSplitChart.test.jsx
+++ b/frontend/src/components/__tests__/DayNightSplitChart.test.jsx
@@ -31,6 +31,16 @@ test('computeDayNightMiles sums miles by time of day', () => {
   expect(night).toBeCloseTo(1);
 });
 
+test('computeDayNightMiles respects custom boundaries', () => {
+  const acts = [
+    { startTimeLocal: '2023-01-01T05:00:00', distance: 1609.34 },
+    { startTimeLocal: '2023-01-01T07:00:00', distance: 1609.34 },
+  ];
+  const { day, night } = computeDayNightMiles(acts, 7, 19);
+  expect(day).toBeCloseTo(1);
+  expect(night).toBeCloseTo(1);
+});
+
 test('renders total miles label', async () => {
   const acts = [
     { startTimeLocal: '2023-01-01T10:00:00', distance: 1600 },


### PR DESCRIPTION
## Summary
- allow custom day boundary hours when computing the split
- show miles and percentages in the chart tooltip
- add a legend displaying day vs night values
- test custom boundary behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688992c53c2c8324868c09c30c58f59f