### PR TITLE
Update fitness dial colors

### DIFF
--- a/frontend/src/components/FitnessScoreDial.jsx
+++ b/frontend/src/components/FitnessScoreDial.jsx
@@ -19,9 +19,9 @@ function Dial({ score, size = 120 }) {
   const cy = size / 2;
   const r = size / 2 - 10;
   const zones = [
-    { start: -90, end: -90 + 144, className: "stroke-red-500" },
-    { start: -90 + 144, end: -90 + 252, className: "stroke-yellow-500" },
-    { start: -90 + 252, end: 270, className: "stroke-green-500" },
+    { start: -90, end: -90 + 144, color: "hsl(var(--destructive))" },
+    { start: -90 + 144, end: -90 + 252, color: "hsl(var(--accent))" },
+    { start: -90 + 252, end: 270, color: "hsl(var(--primary))" },
   ];
   const needleAngle = -90 + (score / 100) * 360;
   const needle = polarToCartesian(cx, cy, r - 8, needleAngle);
@@ -32,8 +32,9 @@ function Dial({ score, size = 120 }) {
         <path
           key={i}
           d={describeArc(cx, cy, r, z.start, z.end)}
-          className={z.className}
+          stroke={z.color}
           strokeWidth={10}
+          strokeLinecap="round"
           fill="none"
         />
       ))}


### PR DESCRIPTION
## Summary
- style dial arcs with site color variables and round caps

## Testing
- `npm run test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688994a232f083249b4a13b0f9364684