### PR TITLE
Remove step sparkline; style streak count

### DIFF
--- a/frontend/src/components/StreakFlame.jsx
+++ b/frontend/src/components/StreakFlame.jsx
@@ -39,7 +39,7 @@ export default function StreakFlame({ count }) {
   return (
     <div className="flex items-center" title={`${days} day streak`}>
       <Flame className={`lucide-flame ${levels[idx]} ${days ? 'animate-pulse' : ''}`} />
-      <span className="ml-1 text-xs font-medium">{days}</span>
+      <span className={`ml-1 text-xs font-medium ${levels[idx]}`}>{days}</span>
     </div>
   );
 }

--- a/frontend/src/components/WeeklySummaryCard.jsx
+++ b/frontend/src/components/WeeklySummaryCard.jsx
@@ -259,13 +259,6 @@ export default function WeeklySummaryCard({ children }) {
           <div className="flex items-end gap-4">
             <div className="h-8 w-20">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={filteredSteps} margin={{ top: 2, bottom: 2 }}>
-                  <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill="none" dot={false} />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-            <div className="h-8 w-20">
-              <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={filteredSleep} margin={{ top: 2, bottom: 2 }}>
                   <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" fill="none" dot={false} />
                 </LineChart>


### PR DESCRIPTION
## Summary
- show flame streak count in the same color as the flame
- keep only the sleep trend line in the summary card

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899463b87c8324b40f667e11f9d218