### PR TITLE
Update favicon with theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,14 +4,17 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-  <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)">
-  <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)">
+  <link id="favicon" rel="icon" href="/favicon-light.svg">
   <script>
     (function() {
       const ls = localStorage.theme;
       const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
       const theme = ls === 'dark' || (!ls && prefers) ? 'dark' : 'light';
       document.documentElement.classList.toggle('dark', theme === 'dark');
+      const favicon = document.getElementById('favicon');
+      if (favicon) {
+        favicon.href = theme === 'dark' ? '/favicon-dark.svg' : '/favicon-light.svg';
+      }
     })();
   </script>
     <!-- load globals.css (defines CSS vars + Tailwind) -->

--- a/frontend/src/components/ModeToggle.jsx
+++ b/frontend/src/components/ModeToggle.jsx
@@ -6,14 +6,24 @@ export default function ModeToggle() {
   const [isDark, setIsDark] = React.useState(false);
 
   React.useEffect(() => {
-    setIsDark(document.documentElement.classList.contains("dark"));
+    const dark = document.documentElement.classList.contains("dark");
+    setIsDark(dark);
+    updateFavicon(dark);
   }, []);
+
+  function updateFavicon(dark) {
+    const favicon = document.getElementById("favicon");
+    if (favicon) {
+      favicon.href = dark ? "/favicon-dark.svg" : "/favicon-light.svg";
+    }
+  }
 
   function toggle() {
     const root = document.documentElement;
     const newDark = !root.classList.contains("dark");
     root.classList.toggle("dark", newDark);
     localStorage.theme = newDark ? "dark" : "light";
+    updateFavicon(newDark);
     setIsDark(newDark);
   }
 


### PR DESCRIPTION
## Summary
- ensure `ModeToggle` updates favicon href when switching themes
- load a single favicon and swap the icon in the startup script

## Testing
- `npm test --silent`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898cd9c0b88324a5cf4ba67e0b458b