### PR TITLE
Add legend styling for treadmill vs outdoor chart

### DIFF
--- a/frontend/src/components/DemoCharts/DemoCharts.jsx
+++ b/frontend/src/components/DemoCharts/DemoCharts.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import {
-  PieChart, Pie, Cell,
-  RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar,
+  PieChart,
+  Pie,
+  Cell,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
   ResponsiveContainer,
-  Tooltip, Label,
+  Tooltip,
+  Label,
 } from 'recharts';
 import { modeData, timeData, mileageData } from './data';
+import { Card, CardHeader, CardTitle, CardContent } from '../ui/Card';
+import ModeLegend from '../ModeLegend';
 
 // Use theme-based colors so the charts adapt to light and dark modes
 const COLORS = ['hsl(var(--primary))', 'hsl(var(--muted-foreground))'];
@@ -13,35 +22,42 @@ const TIME_COLOR = 'hsl(var(--primary))';
 const MILEAGE_COLOR = 'hsl(var(--accent))';
 
 export default function DemoCharts() {
+  const total = modeData[0].value + modeData[1].value;
+  const tPct = (modeData[0].value / total) * 100;
+  const oPct = (modeData[1].value / total) * 100;
   return (
     <div className="space-y-8 p-6 bg-background text-foreground rounded-xl relative">
       {/* 1) Donut */}
-      <div className="text-center">
-        <h2 className="text-lg font-semibold">Treadmill vs Outdoor</h2>
-        <p className="text-sm text-muted-foreground">Andy runs inside a lot</p>
-        <div className="relative mx-auto" style={{ width: 200, height: 200 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={modeData}
-                cx="50%" cy="50%"
-                innerRadius={60} outerRadius={90}
-                dataKey="value"
-                startAngle={90} endAngle={-270}
-              >
-                {modeData.map((_, idx) => (
-                  <Cell key={idx} fill={COLORS[idx]} />
-                ))}
-                <Label
-                  value={`${modeData[0].value}% / ${modeData[1].value}%`}
-                  position="center"
-                />
-              </Pie>
-              <Tooltip formatter={(v, n) => [`${v}%`, n]} />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+      <Card className="animate-in fade-in">
+        <CardHeader>
+          <CardTitle>Treadmill vs Outdoor</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={modeData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  dataKey="value"
+                  startAngle={90}
+                  endAngle={-270}
+                >
+                  {modeData.map((_, idx) => (
+                    <Cell key={idx} fill={COLORS[idx]} />
+                  ))}
+                  <Label value={`${modeData[0].value}% / ${modeData[1].value}%`} position="center" />
+                </Pie>
+                <Tooltip formatter={(v, n) => [`${v}%`, n]} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <ModeLegend treadmillPct={tPct} outdoorPct={oPct} colors={COLORS} />
+        </CardContent>
+      </Card>
 
       <div className="grid md:grid-cols-2 gap-12">
         {/* 2) Activity by Time */}

--- a/frontend/src/components/ModeLegend.jsx
+++ b/frontend/src/components/ModeLegend.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function ModeLegend({ treadmillPct = 0, outdoorPct = 0, colors = [] }) {
+  const treadmillColor = colors[0] || 'hsl(var(--primary))';
+  const outdoorColor = colors[1] || 'hsl(var(--muted-foreground))';
+  return (
+    <div className="flex items-center gap-4 mt-4 text-sm">
+      <div className="flex items-center gap-1">
+        <span className="w-4 h-4 rounded-sm" style={{ backgroundColor: treadmillColor }}></span>
+        <span>Treadmill ({treadmillPct.toFixed(0)}%)</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="w-4 h-4 rounded-sm" style={{ backgroundColor: outdoorColor }}></span>
+        <span>Outdoor ({outdoorPct.toFixed(0)}%)</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ModeLegend` for treadmill/outdoor donut chart
- style treadmill vs outdoor chart like the Day/Night chart using a Card and legend

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68899bee85b88324b69bba8cc3d7ac12