### PR TITLE
Fix TimeCapsule default open month

### DIFF
--- a/frontend/src/components/TimeCapsule.jsx
+++ b/frontend/src/components/TimeCapsule.jsx
@@ -30,6 +30,13 @@ export default function TimeCapsule() {
 
   const keys = Object.keys(months).sort();
 
+  // Open the newest month once data has loaded
+  React.useEffect(() => {
+    if (open === null && keys.length) {
+      setOpen(keys[keys.length - 1]);
+    }
+  }, [keys, open]);
+
   function toggle(key) {
     setOpen((prev) => (prev === key ? null : key));
   }

--- a/frontend/src/components/__tests__/TimeCapsule.test.jsx
+++ b/frontend/src/components/__tests__/TimeCapsule.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import TimeCapsule from '../TimeCapsule';
+
+afterEach(() => vi.restoreAllMocks());
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() { this.cb([{ contentRect: { width: 100, height: 80 } }]); }
+    unobserve() {}
+    disconnect() {}
+  };
+  HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 100,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 100,
+  });
+});
+
+test('opens newest month after fetching totals', async () => {
+  const totals = [
+    { date: '2023-01-15', distance: 1000, duration: 0 },
+    { date: '2023-02-20', distance: 2000, duration: 0 },
+  ];
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(totals),
+  });
+
+  render(<TimeCapsule />);
+
+  const detail = await screen.findByText(/February 2023/);
+  expect(detail.textContent).toMatch(/2\.0 km/);
+});


### PR DESCRIPTION
## Summary
- auto-open the latest month in `TimeCapsule`
- test that newest month details show by default

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68899fef24908324830fe8c7620cfe12