### PR TITLE
Use CSS vars for chart colors

### DIFF
--- a/frontend/src/components/CumulativeTimeChart.jsx
+++ b/frontend/src/components/CumulativeTimeChart.jsx
@@ -76,7 +76,11 @@ export default function CumulativeTimeChart() {
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-              <CartesianGrid stroke="#E5E7EB" strokeWidth={1} horizontal={false} />
+              <CartesianGrid
+                stroke="hsl(var(--border))"
+                strokeWidth={1}
+                horizontal={false}
+              />
               <XAxis dataKey="month" />
               <YAxis unit="h" />
               <Tooltip formatter={(v) => `${v.toFixed(1)} h`} />

--- a/frontend/src/components/ElevationChart.jsx
+++ b/frontend/src/components/ElevationChart.jsx
@@ -64,7 +64,11 @@ export default function ElevationChart({ points = [], activeIndex = null }) {
       <div className="h-40">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid stroke="#E5E7EB" strokeWidth={1} strokeDasharray="4 4" />
+            <CartesianGrid
+              stroke="hsl(var(--border))"
+              strokeWidth={1}
+              strokeDasharray="4 4"
+            />
             <XAxis dataKey="dist" unit="km" />
             <YAxis dataKey="elevation" unit="m" />
             <Tooltip content={<ElevationTooltip />} />

--- a/frontend/src/components/PaceDistributionChart.jsx
+++ b/frontend/src/components/PaceDistributionChart.jsx
@@ -79,7 +79,11 @@ export default function PaceDistributionChart() {
               width={60}
               tick={{ fill: "var(--foreground)", fontSize: 12 }}
             />
-            <ReferenceLine x={0} stroke="#64748B" strokeDasharray="3 3" />
+            <ReferenceLine
+              x={0}
+              stroke="hsl(var(--muted-foreground))"
+              strokeDasharray="3 3"
+            />
             <ReferenceLine
               x={0}
               label={{

--- a/frontend/src/components/VirtualPathMap.jsx
+++ b/frontend/src/components/VirtualPathMap.jsx
@@ -73,7 +73,10 @@ export default function VirtualPathMap() {
     <div className="h-64">
       <MapContainer center={[center.lat, center.lon]} zoom={4} style={{ height: "100%", width: "100%" }}>
         <TileLayer url={tileUrl} attribution={cartoAttribution} />
-        <Polyline positions={route.map(p => [p.lat, p.lon])} pathOptions={{ color: '#ccc', dashArray: '4' }} />
+        <Polyline
+          positions={route.map((p) => [p.lat, p.lon])}
+          pathOptions={{ color: 'hsl(var(--border))', dashArray: '4' }}
+        />
         {traveled.length > 0 && (
           <Polyline positions={[[route[0].lat, route[0].lon], ...traveled.map(p => [p.lat, p.lon])]} pathOptions={{ color: 'hsl(var(--primary))' }} />
         )}

--- a/frontend/src/components/WeatherImpactBubbleChart.jsx
+++ b/frontend/src/components/WeatherImpactBubbleChart.jsx
@@ -66,7 +66,7 @@ export default function WeatherImpactBubbleChart({ start, end } = {}) {
         {!loading && !error && data.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">
             <ScatterChart margin={{ top: 5, right: 20, bottom: 20, left: 0 }}>
-              <CartesianGrid stroke="#E5E7EB" />
+              <CartesianGrid stroke="hsl(var(--border))" />
               <XAxis type="number" dataKey="temperature" unit="°C" />
               <YAxis type="number" dataKey="avgHeartRate" unit="bpm" />
               <ZAxis type="number" dataKey="distanceKm" range={[30, 200]} />


### PR DESCRIPTION
## Summary
- replace hard-coded hex colors with theme CSS variables

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a075f32d88324b9f04ca3da790d8f