### PR TITLE
Deploy backend as Vercel function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ Add the `VITE_BACKEND_URL` environment variable in the Vercel dashboard so the
 frontend knows where to reach your backend. Vercel will run `npm run build` and
 serve the generated static files from `frontend/dist`.
 
-The backend can be hosted separately on any platform that supports FastAPI. For
-monorepo deployments you may place a FastAPI app inside the `api/` folder and
-create a `vercel.json` file that rewrites `/api/*` requests to that serverless
-function.
+This repository now includes the FastAPI backend under `api/index.py`. Deploy
+it as a serverless function by adding a `vercel.json` file that rewrites
+requests to `/api/*` to that function:
+
+```json
+{
+  "rewrites": [{ "source": "/api/(.*)", "destination": "/api/index.py" }]
+}
+```
+
+Set `VITE_BACKEND_URL` to `/api` when deploying so the frontend calls the
+serverless endpoints.
 
 ## Frontend Features
 

--- a/api/hello.py
+++ b/api/hello.py
@@ -1,6 +1,0 @@
-def handler(request):
-    return {
-        "statusCode": 200,
-        "headers": { "Content-Type": "application/json" },
-        "body": '{"message": "Hello from Vercel Python!"}'
-    }

--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,0 @@
-export default function handler(req, res) {
-  res.status(200).json({
-    message: "Backend is working!",
-    steps: 8421,
-    sleep: 7,
-    hrAvg: 110,
-  });
-}

--- a/api/index.py
+++ b/api/index.py
@@ -1,26 +1,8 @@
-from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+import os
+import sys
 
-app = FastAPI()
+# Add the backend package to sys.path so we can import the FastAPI app
+BACKEND_PATH = os.path.join(os.path.dirname(__file__), "..", "backend")
+sys.path.insert(0, os.path.abspath(BACKEND_PATH))
 
-@app.get("/steps")
-def get_steps():
-    return JSONResponse({
-        "steps": [6500, 7200, 8300, 9000, 7500, 8100, 7005]
-    })
-
-@app.get("/sleep")
-def get_sleep():
-    return JSONResponse({
-        "sleep_hours": [7.2, 6.8, 8.0, 7.5, 7.0, 7.8, 8.1]
-    })
-
-@app.get("/heartrate")
-def get_heartrate():
-    return JSONResponse({
-        "heartrate": [65, 70, 68, 72, 69, 71, 67]
-    })
-
-@app.get("/")
-def root():
-    return {"message": "API is live"}
+from app.main import app  # noqa: E402

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- move FastAPI backend into `api/index.py`
- remove example Node/hello endpoints
- add a `vercel.json` rewrite
- document the Vercel deployment process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889a20366ec832482e99cd447a759ab