### PR TITLE
Set shadcn baseColor to blue

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "tailwind.config.js",
     "css": "src/styles/globals.css",
-    "baseColor": "neutral",
+    "baseColor": "blue",
     "cssVariables": true,
     "prefix": ""
   },


### PR DESCRIPTION
## Summary
- sync the shadcn base color with the blue palette used in globals.css

## Testing
- `pytest backend/tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a09eef1fc8324af3d1adc4081cb8f