### PR TITLE
Patch deterministic weather data in track test

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -79,7 +79,19 @@ def test_map_endpoint():
     _check_metric_list('/map')
 
 
-def test_activity_track():
+def test_activity_track(monkeypatch):
+    from app import weather
+
+    def fake_weather(lat, lon, ts):
+        return {
+            "temperature": 22,
+            "precipitation": 0.0,
+            "windspeed": 3.2,
+            "humidity": 55,
+        }
+
+    monkeypatch.setattr(weather, "get_weather", fake_weather)
+
     list_resp = client.get('/activities')
     aid = list_resp.json()[0]['activityId']
     resp = client.get(f'/activities/{aid}/track')


### PR DESCRIPTION
## Summary
- avoid external HTTP calls in `test_activity_track`
- patch `weather.get_weather` to return a fixed response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a11d089a08324965d153515b1ba68