### PR TITLE
Fix vercel runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ the **Build Command** as `cd frontend && npm install && npm run build`. Add the
 knows where to reach your backend. Vercel will execute this command and serve
 the generated static files from `frontend/dist`.
 
+Ensure your local Vercel CLI is up to date before deploying. Run
+`npm i -g vercel` to install the latest version. Older CLI releases cannot
+parse modern runtime identifiers and will fail with a
+`Function Runtimes must have a valid version` error.
+
 This repository now includes the FastAPI backend under `api/index.py`. Deploy
 it as a serverless function by adding a `vercel.json` file that rewrites
 requests to `/api/*` to that function:

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.py": {
-      "runtime": "python3.11"
+      "runtime": "vercel-python@5.0.0"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- use explicit `vercel-python@5.0.0` runtime for compatibility
- note Vercel CLI update requirement in README

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a23fb4794832481b7fd2bb402b7f0