### PR TITLE
Fix README setup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ environment.
 
    # 2. upgrade pip & install deps
    pip install --upgrade pip
-   pip install -r ../requirements.txt
+   pip install -r ../api/requirements.txt
 
    # 3. make sure uvicorn is installed
-   #    (uvicorn is in ../requirements.txt, so pip install -r should have put it in .venv)
+   #    (uvicorn is in ../api/requirements.txt, so pip install -r should have put it in .venv)
 
    # 4. run the server
    uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ The generated activities are located around **Madison, Wisconsin** for use in th
    python3 -m venv .venv
    source .venv/bin/activate
    pip install --upgrade pip
-   pip install -r ../requirements.txt
+   pip install -r ../api/requirements.txt
    ```
 3. Run the server:
    ```bash


### PR DESCRIPTION
## Summary
- update backend setup instructions to use `api/requirements.txt`

## Testing
- `pytest backend/tests`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a2ec606188324a9f3fb36098b9f1e