### PR TITLE
Clarify Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.py": {
-      "runtime": "vercel-python@3.9"
+      "runtime": "python3.11"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- document local vs serverless backends
- add clear Vercel deployment instructions
- switch runtime to python3.11

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a5780bbcc8324a047cf478e317658