### PR TITLE
Add top-level tabs to organize dashboard sections

### DIFF
--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -1,62 +1,11 @@
 import React from "react";
-import { Card, CardContent } from "./ui/Card";
-import KPIGrid from "./KPIGrid";
-import WeatherChart from "./WeatherChart";
-import TemperatureChart from "./TemperatureChart";
-
-import StatesVisited from "./StatesVisited";
-import WeeklySummaryCard from "./WeeklySummaryCard";
-import FitnessScoreDial from "./FitnessScoreDial";
-import StreakFlame from "./StreakFlame";
-import TimeCapsule from "./TimeCapsule";
-const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
-const VirtualPathMap = React.lazy(() => import("./VirtualPathMap"));
+import DashboardTabs from "./DashboardTabs";
 
 
 export default function DashboardPage() {
   return (
-    <div className="space-y-6 p-6">
-
-      <h2 className="text-2xl font-bold mb-2">Activity Overview</h2>
-
-      <WeeklySummaryCard>
-        <StreakFlame />
-      </WeeklySummaryCard>
-
-      <React.Suspense
-        fallback={
-          <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
-            Loading analysis...
-          </div>
-        }
-      >
-        <AnalysisSection />
-      </React.Suspense>
-
-      <div className="grid gap-6 sm:grid-cols-2">
-        <TemperatureChart />
-        <WeatherChart />
-      </div>
-      <StatesVisited />
-      <Card className="animate-in fade-in">
-        <CardContent className="space-y-6">
-          <KPIGrid />
-
-          <FitnessScoreDial />
-
-          <React.Suspense
-            fallback={
-              <div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">
-                Loading virtual map...
-              </div>
-            }
-          >
-            <VirtualPathMap />
-          </React.Suspense>
-
-        </CardContent>
-      </Card>
-      <TimeCapsule />
+    <div className="p-6">
+      <DashboardTabs />
     </div>
   );
 }

--- a/frontend/src/components/DashboardTabs.jsx
+++ b/frontend/src/components/DashboardTabs.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "./ui/Tabs";
+import WeeklySummaryCard from "./WeeklySummaryCard";
+import StreakFlame from "./StreakFlame";
+import KPIGrid from "./KPIGrid";
+import FitnessScoreDial from "./FitnessScoreDial";
+import TemperatureChart from "./TemperatureChart";
+import WeatherChart from "./WeatherChart";
+const AnalysisSection = React.lazy(() => import("./AnalysisSection"));
+const MapSection = React.lazy(() => import("./MapSection"));
+import StatesVisited from "./StatesVisited";
+const VirtualPathMap = React.lazy(() => import("./VirtualPathMap"));
+import CumulativeChart from "./CumulativeChart";
+import CumulativeTimeChart from "./CumulativeTimeChart";
+import TimeCapsule from "./TimeCapsule";
+
+export default function DashboardTabs() {
+  return (
+    <Tabs defaultValue="overview" className="space-y-6">
+      <TabsList className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="trends">Trends</TabsTrigger>
+        <TabsTrigger value="routes">Routes & Geography</TabsTrigger>
+        <TabsTrigger value="capsule">Time Capsule</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview" className="space-y-6">
+        <WeeklySummaryCard>
+          <StreakFlame />
+        </WeeklySummaryCard>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <TemperatureChart />
+          <WeatherChart />
+        </div>
+        <KPIGrid />
+        <FitnessScoreDial />
+      </TabsContent>
+      <TabsContent value="trends" className="space-y-10">
+        <React.Suspense fallback={<div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">Loading analysis...</div>}>
+          <AnalysisSection />
+        </React.Suspense>
+      </TabsContent>
+      <TabsContent value="routes" className="space-y-6">
+        <React.Suspense fallback={<div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">Loading map...</div>}>
+          <MapSection />
+        </React.Suspense>
+        <StatesVisited />
+      </TabsContent>
+      <TabsContent value="capsule" className="space-y-6">
+        <CumulativeChart />
+        <CumulativeTimeChart />
+        <React.Suspense fallback={<div className="h-64 flex items-center justify-center text-sm font-normal text-muted-foreground">Loading route...</div>}>
+          <VirtualPathMap />
+        </React.Suspense>
+        <TimeCapsule />
+      </TabsContent>
+    </Tabs>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `DashboardTabs` component that groups dashboard content under tabs
- simplify `DashboardPage` by rendering `DashboardTabs`
- keep sections for Overview, Trends, Routes & Geography, and Time Capsule

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a73152454832490e3b2cd380bbc46