### PR TITLE
Add persistent navigation and update layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ viewer to switch between the traditional 3D track and a rotating earth view.
 All of the map-based views are grouped under a new **Maps** tab, bringing the
 route viewer, timeline and virtual path tracker together in one place.
 
+Navigation links for **Dashboard**, **Charts**, **Maps** and **Components** now
+appear in a persistent top bar with the site title on the left so you can switch
+pages at any time.
+
 ## Tailwind Theme Setup
 
 The `src/main.jsx` entry point imports `@/index.css` which includes `tailwindcss-shadcn-ui/style.css` so shadcn/ui component styles are loaded. The interface uses icons from the **Lucide** set via the `lucide-react` package.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,45 +3,14 @@ import DashboardPage from "@/components/DashboardPage";
 import AllChartsPage from "@/components/AllChartsPage";
 import AllMapsPage from "@/components/AllMapsPage";
 import AllComponentsPage from "@/components/AllComponentsPage";
-import ModeToggle from "@/components/ModeToggle";
+import NavBar from "@/components/NavBar";
 
 export default function App() {
   const [page, setPage] = React.useState("dashboard");
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="p-4 flex justify-between">
-        {page === "dashboard" ? (
-          <div className="space-x-2">
-            <button
-              className="text-sm underline"
-              onClick={() => setPage("charts")}
-            >
-              View All Charts
-            </button>
-            <button
-              className="text-sm underline"
-              onClick={() => setPage("maps")}
-            >
-              View All Maps
-            </button>
-            <button
-              className="text-sm underline"
-              onClick={() => setPage("components")}
-            >
-              View Components
-            </button>
-          </div>
-        ) : (
-          <button
-            className="text-sm underline"
-            onClick={() => setPage("dashboard")}
-          >
-            Back to Dashboard
-          </button>
-        )}
-        <ModeToggle />
-      </div>
+      <NavBar page={page} setPage={setPage} />
       <main className="mx-auto max-w-[1200px]">
         {page === "dashboard" ? (
           <DashboardPage />

--- a/frontend/src/components/AllChartsPage.jsx
+++ b/frontend/src/components/AllChartsPage.jsx
@@ -11,6 +11,7 @@ import AnalysisSection from "./AnalysisSection";
 export default function AllChartsPage() {
   return (
     <div className="p-6 space-y-6">
+      <h1 className="text-lg font-semibold">All Charts</h1>
       <WeeklySummaryCard>
         <StreakFlame />
       </WeeklySummaryCard>

--- a/frontend/src/components/AllMapsPage.jsx
+++ b/frontend/src/components/AllMapsPage.jsx
@@ -5,6 +5,7 @@ import VirtualPathMap from "./VirtualPathMap";
 export default function AllMapsPage() {
   return (
     <div className="p-6 space-y-6">
+      <h1 className="text-lg font-semibold">All Maps</h1>
       <MapSection />
       <VirtualPathMap />
     </div>

--- a/frontend/src/components/DashboardTabs.jsx
+++ b/frontend/src/components/DashboardTabs.jsx
@@ -20,6 +20,7 @@ export default function DashboardTabs() {
         <TabsTrigger value="maps">Maps</TabsTrigger>
       </TabsList>
       <TabsContent value="overview" className="space-y-6">
+        <h2 className="text-base font-semibold">Activity Overview</h2>
         <WeeklySummaryCard>
           <StreakFlame />
         </WeeklySummaryCard>

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ModeToggle from "./ModeToggle";
+
+export default function NavBar({ page, setPage }) {
+  const links = [
+    { label: "Dashboard", value: "dashboard" },
+    { label: "Charts", value: "charts" },
+    { label: "Maps", value: "maps" },
+    { label: "Components", value: "components" },
+  ];
+
+  return (
+    <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex max-w-[1200px] items-center justify-between p-4">
+        <div className="font-semibold">Garmin Dashboard</div>
+        <nav className="flex items-center gap-3">
+          {links.map((link) => (
+            <button
+              key={link.value}
+              onClick={() => setPage(link.value)}
+              className={
+                "text-sm" + (page === link.value ? " font-semibold underline" : " underline")
+              }
+            >
+              {link.label}
+            </button>
+          ))}
+          <ModeToggle />
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- create `NavBar` component with links and dark mode toggle
- use `NavBar` in `App` for consistent navigation
- add "Activity Overview" heading on the dashboard
- label "All Charts" and "All Maps" pages with headers
- document persistent nav in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688adb366fc48324a63a4aaf460552e4